### PR TITLE
Fixes a bug with `install` view(s) into scroll views where the conten…

### DIFF
--- a/Form/UIScrollView+Keyboard.swift
+++ b/Form/UIScrollView+Keyboard.swift
@@ -79,6 +79,7 @@ public extension UIScrollView {
 
     /// Will dynamically update `isScrollEnabled` to be disabled when content fits.
     /// - Returns: A disposable that will stop adjustments when being disposed.
+    @available(*, deprecated, message: "use `alwaysBounceVertical = false` instead")
     func disableScrollingIfContentFits() -> Disposable {
         return combineLatest(signal(for: \.frame), signal(for: \.contentSize), signal(for: \.contentInset)).map { frame, contentSize, contentInset in
             (UIEdgeInsetsInsetRect(frame, contentInset).size, contentSize)

--- a/Form/UIViewController+Install.swift
+++ b/Form/UIViewController+Install.swift
@@ -112,9 +112,7 @@ private extension UIViewController {
     func installScrollView<T: UIScrollView>(_ scrollView: T, options: InstallOptions, onInstall: ((T) -> Void)?) -> Disposable {
         let bag = DisposeBag()
 
-        if options.contains(.disableScrollingIfContentFits) {
-            bag += scrollView.disableScrollingIfContentFits()
-        }
+        scrollView.alwaysBounceVertical = !options.contains(.disableScrollingIfContentFits)
 
         bag += combineLatest(scrollView.didMoveToWindowSignal, scrollView.didLayoutSignal).onFirstValue { _ in
             if self.automaticallyAdjustsScrollViewInsets {


### PR DESCRIPTION
…t fits but the scroll view still won't scroll even though `InstallOptions.disableScrollingIfContentFits` was not provided.

Deprecated `disableScrollingIfContentFits()` as this is better supported by UIScrollViews's `alwaysBounceVertical = false`
The above change will also make installing of view(s) into scroll views or installing of table views (via TableKit) to become more consistent (table view has alwaysBounceVertical == true per default where as scroll view has it set to false)