### PR TITLE
Fixes a bug in SelectView where tapping inside but releasing outside …

### DIFF
--- a/Form/SelectView.swift
+++ b/Form/SelectView.swift
@@ -71,10 +71,12 @@ public final class SelectView: UIView, Selectable, Highlightable {
     }
 
     public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        if callbacker.isEmpty && detectFirstResponder {
-            firstPossibleResponder?.becomeFirstResponder()
-        } else {
-            callbacker.callAll(with: ())
+        if isSingleAndInside(touches) {
+            if callbacker.isEmpty && detectFirstResponder {
+                firstPossibleResponder?.becomeFirstResponder()
+            } else {
+                callbacker.callAll(with: ())
+            }
         }
 
         guard let didHighlightTime = autoHighlightTime else { return }


### PR DESCRIPTION
…would call the callback or find first responder (especially apparent when in a views that are not scrollable) This was likely a regression after fixing another issues with finding first responders.