### PR TITLE
Force ValueField to never have autocorrection enabled as setting it t…

### DIFF
--- a/Form/ValueField.swift
+++ b/Form/ValueField.swift
@@ -151,7 +151,13 @@ public final class ValueField<Value>: UIControl, UIKeyInput {
     }
 
     public dynamic var returnKeyType: UIReturnKeyType = .default
-    public dynamic var autocorrectionType: UITextAutocorrectionType = .default
+
+    /// Always use `.no` autocorrection as the system keyboard will be confused if it is used.
+    public dynamic var autocorrectionType: UITextAutocorrectionType {
+        get { return .no }
+        set { /* ignore */ }
+    }
+    
     public dynamic var keyboardType: UIKeyboardType = .default
 
     public override var intrinsicContentSize: CGSize {
@@ -283,7 +289,6 @@ private extension ValueField {
         placeholderLabel.style = style.placeholder
         cursor.backgroundColor = style.cursorColor
         returnKeyType = style.returnKey
-        autocorrectionType = style.autocorrection
         keyboardType = style.keyboard
         updateAlignmentConstraints()
     }


### PR DESCRIPTION
…o `.yes` causes weird keyboard rendering artifacts

￼
<img width="559" alt="pasted graphic" src="https://user-images.githubusercontent.com/1104183/44660902-59a1be80-aa09-11e8-9028-5d65e16af1c4.png">
