### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+- Adds a ScrollViewDelegate class implementing the UIScrollViewDelegate protocol
+- Updates NumberEditor to handle entering and editing of negative value
+- Disables autocorrection for ValueField by defualt
+- Adds a new API for providing view for empty table view state which pins it to the edges of the table view. The old API that is using hardcoded insets and doesn't pin all edges is now deprecated.
+
 ## 1.0.2
 
 - Fixes a bug with `install` view(s) into scroll views where the content fits but the scroll view still won't scroll even though `InstallOptions.disableScrollingIfContentFits`` was not provided.

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.0.2"
+  s.version      = "1.1.0"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- Adds a ScrollViewDelegate class implementing the UIScrollViewDelegate protocol
- Updates NumberEditor to handle entering and editing of negative value
- Disables autocorrection for ValueField by defualt
- Adds a new API for providing view for empty table view state which pins it to the edges of the table view. The old API that is using hardcoded insets and doesn't pin all edges is now deprecated.