### PR TITLE
TableKit cell dispose bag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.1
+- Bugfix: Updated TableKit to release the a cell's bag once the cell ends displaying or the TableKit's bag is being disposed.
+
 ## 1.1.0
 - Adds a ScrollViewDelegate class implementing the UIScrollViewDelegate protocol
 - Updates NumberEditor to handle entering and editing of negative value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.1.1
+- Added didEndDisplayingCell signal to TableViewDelegate
 - Bugfix: Updated TableKit to release the a cell's bag once the cell ends displaying or the TableKit's bag is being disposed.
 
 ## 1.1.0

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -174,6 +174,16 @@ public final class TableKit<Section, Row> {
             return cell
         }
 
+        bag += delegate.didEndDisplayingCell.onValue { cell in
+            cell.releaseBag(forType: Row.self)
+        }
+
+        bag += {
+            for cell in view.visibleCells {
+                cell.releaseBag(forType: Row.self)
+            }
+        }
+
         // Reordering
         bag += delegate.didReorderRow.onValue { (source: TableIndex, destination: TableIndex) in
             self.updatePositionsOfVisibleCells { index in

--- a/Form/TableViewDelegate.swift
+++ b/Form/TableViewDelegate.swift
@@ -22,6 +22,7 @@ public final class TableViewDelegate<Section, Row>: ScrollViewDelegate, UITableV
     private let didSelectCallbacker = Callbacker<TableIndex>()
     private let didReorderCallbacker = Callbacker<(source: TableIndex, destination: TableIndex)>()
     private let willDisplayCellCallbacker = Callbacker<(UITableViewCell, TableIndex)>()
+    private let didEndDisplayingCellCallbacker = Callbacker<UITableViewCell>()
     private var actions = [(UITableViewRowAction, (TableIndex) -> Bool)]()
 
     public var table: Table<Section, Row>
@@ -94,6 +95,10 @@ public final class TableViewDelegate<Section, Row>: ScrollViewDelegate, UITableV
         willDisplayCellCallbacker.callAll(with: (cell, tableIndex))
     }
 
+    public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        didEndDisplayingCellCallbacker.callAll(with: cell)
+    }
+
     public func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
         let sourceIndexPath = TableIndex(section: sourceIndexPath.section, row: sourceIndexPath.row)
         let toIndex = TableIndex(section: proposedDestinationIndexPath.section, row: proposedDestinationIndexPath.row)
@@ -120,6 +125,10 @@ public extension TableViewDelegate {
 
     var willDisplayCell: Signal<(UITableViewCell, TableIndex)> {
         return Signal(callbacker: willDisplayCellCallbacker)
+    }
+
+    var didEndDisplayingCell: Signal<UITableViewCell> {
+        return Signal(callbacker: didEndDisplayingCellCallbacker)
     }
 
     var didReorderRow: Signal<(source: TableIndex, destination: TableIndex)> {

--- a/Form/UITableViewCell+Utilities.swift
+++ b/Form/UITableViewCell+Utilities.swift
@@ -156,6 +156,11 @@ extension UITableViewCell {
         bag += configure(new)
     }
 
+    func releaseBag<Item>(forType: Item.Type) {
+        let (_, bag) = configureAndBag(Item.self)!
+        bag.dispose()
+    }
+
     func updateBackground(forStyle style: DynamicTableViewFormStyle, position: CellPosition) {
         guard let backgroundView = backgroundView as? CellBackgroundView, let selectedBackgroundView = selectedBackgroundView as? CellBackgroundView else {
             self.backgroundView = CellBackgroundView(frame: bounds, style: style, position: position)


### PR DESCRIPTION
- Added didEndDisplayingCell signal to TableViewDelegate
- Bugfix: Updated TableKit to release the a cell's bag once the cell ends displaying or the table kit bag is being disposed.