### PR TITLE
Setting a table's header and footer to a zero height does have the ex…

### DIFF
--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -145,12 +145,12 @@ public final class TableKit<Section, Row> {
 
             self.delegate.headerHeight = style.fixedHeaderHeight ?? (headerForSection == nil ? style.section.header.emptyHeight : UITableViewAutomaticDimension)
             if self.delegate.headerHeight == 0 { // 0 has special meaning, not what we want
-                self.delegate.headerHeight = 0.0000001
+                self.delegate.headerHeight = .headerFooterAlmostZero
             }
 
             self.delegate.footerHeight = style.fixedFooterHeight ?? (footerForSection == nil ? style.section.footer.emptyHeight : UITableViewAutomaticDimension)
             if self.delegate.footerHeight == 0 { // 0 has special meaning, not what we want
-                self.delegate.footerHeight = 0.0000001
+                self.delegate.footerHeight = .headerFooterAlmostZero
             }
         }
 
@@ -396,6 +396,10 @@ public extension MasterDetailSelection where Elements.Index == TableIndex {
 }
 
 #endif
+
+extension CGFloat {
+    static let headerFooterAlmostZero: CGFloat = 0.0000001
+}
 
 private extension Table {
     func isValidIndex(_ index: TableIndex) -> Bool {

--- a/Form/UITableView+Utilities.swift
+++ b/Form/UITableView+Utilities.swift
@@ -82,7 +82,7 @@ private class AutoResizingTableHeaderView: AutoResizingTableSubviewBase {
 
         frame.size.height = embeddedView.bounds.height
         if frame.size.height == 0 { // 0 has special meaning, not what we want
-            frame.size.height = 0.000001
+            frame.size.height = .headerFooterAlmostZero
         }
 
         tableView?.tableHeaderView = self
@@ -95,7 +95,7 @@ private class AutoResizingTableFooterView: AutoResizingTableSubviewBase {
 
         frame.size.height = embeddedView.bounds.height
         if frame.size.height == 0 { // 0 has special meaning, not what we want
-            frame.size.height = 0.000001
+            frame.size.height = .headerFooterAlmostZero
         }
 
         tableView?.tableFooterView = self

--- a/Form/UITableView+Utilities.swift
+++ b/Form/UITableView+Utilities.swift
@@ -81,6 +81,10 @@ private class AutoResizingTableHeaderView: AutoResizingTableSubviewBase {
         super.layoutSubviews()
 
         frame.size.height = embeddedView.bounds.height
+        if frame.size.height == 0 { // 0 has special meaning, not what we want
+            frame.size.height = 0.000001
+        }
+
         tableView?.tableHeaderView = self
     }
 }
@@ -90,6 +94,10 @@ private class AutoResizingTableFooterView: AutoResizingTableSubviewBase {
         super.layoutSubviews()
 
         frame.size.height = embeddedView.bounds.height
+        if frame.size.height == 0 { // 0 has special meaning, not what we want
+            frame.size.height = 0.000001
+        }
+
         tableView?.tableFooterView = self
     }
 }


### PR DESCRIPTION
…pected effect, instead it seems to fallback to default height.

By setting it to a really low value instead of zero we can work around that issue.
This is the same approach used by table kit for it's section headers and footers.