### PR TITLE
Improved support for tables with mixed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.2
+
+- Added `reuseIdentifier` to the `Reusable` protocol to allow better handling of tables with mixed types.
+- Added `Either` conditional conformance to `Reusable` when `Left` and `Right` conforms to `Reusable`.
+- Added alternative helper type `MixedReusable` that can be used instead of `Either` for tables with mixed types.
+- Extended the Demo sample with examples show-casing using tables with mixed types.
+
+- Deprecating `EitherRow`, replaced by using Flows `Either` instead 
+- Deprecating `dequeueCell(forItem:, style:, reuseIdentifier:)`, replaced by version not using explicit `reuseIdentifier`
+
+
 ## 1.1.1
 - Added didEndDisplayingCell signal to TableViewDelegate
 - Bugfix: Updated TableKit to release the a cell's bag once the cell ends displaying or the TableKit's bag is being disposed.

--- a/Documentation/Tables.md
+++ b/Documentation/Tables.md
@@ -55,6 +55,28 @@ extension Item: Reusable {
 
 When conforming to `Reusable` you provide a way to make new views that can be reused and will be configured every time they are reused using a configure function. For rows it is useful to return an instances of `RowView` (see [forms](./forms)).
 
+## Reusable of mixed types
+
+As `Either` conditionally conform to `Resusale` if both `Left` and `Right` do, you can use `Either` to handle tables with mixed types:
+
+```swift
+typealias Row = Either<Int, String>
+let table = Table<(), Row>(rows: [.left(1), .right("A")])
+```
+
+If you have more than two different types you can furhter nest `Either` types:
+
+```swift
+typealias Row = Either<Either<Int, String>, Double>
+let table = Table<(), Row>(rows: [.left(.left(1)), .left(.right("A")), .right(3.14)]])
+```
+
+If you are ok to loose type information you can also consider using the `MixedReusable` helper:
+
+```swift 
+var mixedTable = Table<(), MixedReusable>(rows: [.init(1), .init("A"), .init("B"), .init(2)])
+```
+
 ## TableKit
 
 Once you have your data in a `Table` and your `Row` and `Section` types conforming to `Reusable`, you can construct a `TableKit` that will provide a `UITableView` set up with a proper data source and delegate:

--- a/Documentation/Tables.md
+++ b/Documentation/Tables.md
@@ -64,14 +64,14 @@ typealias Row = Either<Int, String>
 let table = Table<(), Row>(rows: [.left(1), .right("A")])
 ```
 
-If you have more than two different types you can furhter nest `Either` types:
+If you have more than two different types you can further nest `Either` types:
 
 ```swift
 typealias Row = Either<Either<Int, String>, Double>
 let table = Table<(), Row>(rows: [.left(.left(1)), .left(.right("A")), .right(3.14)]])
 ```
 
-If you are ok to loose type information you can also consider using the `MixedReusable` helper:
+If you are ok with losing type information you can also consider using the `MixedReusable` helper:
 
 ```swift 
 var mixedTable = Table<(), MixedReusable>(rows: [.init(1), .init("A"), .init("B"), .init(2)])

--- a/Examples/Demo/Example.xcodeproj/project.pbxproj
+++ b/Examples/Demo/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4C9844A20B25AB01E6B23F2B /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2511AB6F393DD3F7D3FBC2D5 /* Pods_Example.framework */; };
 		F652911320CFC6DF002D665A /* Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F652911220CFC6DF002D665A /* Messages.swift */; };
 		F684177620CE7CCD00AA4E35 /* CustomStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F684177520CE7CCD00AA4E35 /* CustomStyle.swift */; };
 		F6B3E0592086210E00F55C53 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B3E0582086210E00F55C53 /* AppDelegate.swift */; };
@@ -30,6 +31,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2511AB6F393DD3F7D3FBC2D5 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4237EFB1C03450B25AC9AF19 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		680BD49AB995FEECA6DBEE15 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 		F652911220CFC6DF002D665A /* Messages.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
 		F684177520CE7CCD00AA4E35 /* CustomStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomStyle.swift; sourceTree = "<group>"; };
 		F6B3E0552086210E00F55C53 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -46,17 +50,29 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C9844A20B25AB01E6B23F2B /* Pods_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		F5895A25ED79E719F81F9DFE /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4237EFB1C03450B25AC9AF19 /* Pods-Example.debug.xcconfig */,
+				680BD49AB995FEECA6DBEE15 /* Pods-Example.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		F6B3E04C2086210E00F55C53 = {
 			isa = PBXGroup;
 			children = (
 				F6B3E0572086210E00F55C53 /* Example */,
 				F6B3E0562086210E00F55C53 /* Products */,
+				F5895A25ED79E719F81F9DFE /* Pods */,
+				FCB33D0D3622B81A923CAC57 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -83,6 +99,14 @@
 			path = Example;
 			sourceTree = "<group>";
 		};
+		FCB33D0D3622B81A923CAC57 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2511AB6F393DD3F7D3FBC2D5 /* Pods_Example.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -90,10 +114,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F6B3E0672086211100F55C53 /* Build configuration list for PBXNativeTarget "Example" */;
 			buildPhases = (
+				AEE3910006903B97E7160075 /* [CP] Check Pods Manifest.lock */,
 				F6B3E0512086210E00F55C53 /* Sources */,
 				F6B3E0522086210E00F55C53 /* Frameworks */,
 				F6B3E0532086210E00F55C53 /* Resources */,
 				F6B3E0702086224900F55C53 /* Embed Frameworks */,
+				3F18FE9279EE2E75F454BC91 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -147,6 +173,47 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3F18FE9279EE2E75F454BC91 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/FlowFramework/Flow.framework",
+				"${BUILT_PRODUCTS_DIR}/FormFramework/Form.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flow.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Form.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example/Pods-Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AEE3910006903B97E7160075 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Example-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		F6B3E0512086210E00F55C53 /* Sources */ = {
@@ -292,6 +359,7 @@
 		};
 		F6B3E0682086211100F55C53 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4237EFB1C03450B25AC9AF19 /* Pods-Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -309,6 +377,7 @@
 		};
 		F6B3E0692086211100F55C53 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 680BD49AB995FEECA6DBEE15 /* Pods-Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/Examples/Demo/Example/Contents.swift
+++ b/Examples/Demo/Example/Contents.swift
@@ -98,6 +98,18 @@ extension UIViewController {
             bag += section.appendRow(title: "TableKit, Reusable and blending forms header").append(.chevron).onValueDisposePrevious {
                 present { $0.presentTableUsingKitAndReusableWithBlendingFormHeader(style: style) }
             }
+
+            bag += section.appendRow(title: "TableKit and Either Reusable").append(.chevron).onValueDisposePrevious {
+                present { $0.presentTableUsingKitAndEitherReusable(style: style) }
+            }
+
+            bag += section.appendRow(title: "TableKit and Mixed Reusable").append(.chevron).onValueDisposePrevious {
+                present { $0.presentTableUsingKitAndMixedReusable(style: style) }
+            }
+
+            bag += section.appendRow(title: "TableKit and Nested Either Reusable").append(.chevron).onValueDisposePrevious {
+                present { $0.presentTableUsingKitAndNestedEitherReusable(style: style) }
+            }
         }
 
         bag += self.install(form)

--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		21A79B6D1DBF5D84000D1231 /* BackgroundStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A79B6C1DBF5D84000D1231 /* BackgroundStyle.swift */; };
 		21A79B701DBF5DE9000D1231 /* TableViewFormStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A79B6F1DBF5DE9000D1231 /* TableViewFormStyle.swift */; };
 		21D7D99F1E1CE95200CB0FE9 /* ValueLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7D99E1E1CE95200CB0FE9 /* ValueLabel.swift */; };
+		3156BAED2139366B00ECC2EC /* MixedReusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3156BAEC2139366B00ECC2EC /* MixedReusable.swift */; };
 		7270AFB0201FAB7C004DAAA3 /* ViewLayoutArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */; };
 		B35F8AEE1F36676D00904E37 /* Collection+Changes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F8AED1F36676D00904E37 /* Collection+Changes.swift */; };
 		B35F8B4C1F3783E400904E37 /* CollectionDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */; };
@@ -123,11 +124,12 @@
 		213A4D2B1D9A633700F0ADE1 /* Reusable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reusable.swift; path = Form/Reusable.swift; sourceTree = "<group>"; };
 		215D10681DCB80A400504923 /* Utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Utilities.h; path = Form/Utilities.h; sourceTree = SOURCE_ROOT; };
 		215D10691DCB80A400504923 /* Utilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Utilities.m; path = Form/Utilities.m; sourceTree = SOURCE_ROOT; };
-		2191EB5D1D9E9E7800A9B6D0 /* TableKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = TableKit.swift; path = Form/TableKit.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		2191EB5D1D9E9E7800A9B6D0 /* TableKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = TableKit.swift; path = Form/TableKit.swift; sourceTree = "<group>"; };
 		21A79AAC1DBE48E4000D1231 /* HeaderFooterStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HeaderFooterStyle.swift; path = Form/HeaderFooterStyle.swift; sourceTree = "<group>"; };
 		21A79B6C1DBF5D84000D1231 /* BackgroundStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BackgroundStyle.swift; path = Form/BackgroundStyle.swift; sourceTree = "<group>"; };
 		21A79B6F1DBF5DE9000D1231 /* TableViewFormStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TableViewFormStyle.swift; path = Form/TableViewFormStyle.swift; sourceTree = "<group>"; };
 		21D7D99E1E1CE95200CB0FE9 /* ValueLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ValueLabel.swift; path = Form/ValueLabel.swift; sourceTree = "<group>"; };
+		3156BAEC2139366B00ECC2EC /* MixedReusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MixedReusable.swift; path = Form/MixedReusable.swift; sourceTree = "<group>"; };
 		7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewLayoutArea.swift; path = Form/ViewLayoutArea.swift; sourceTree = "<group>"; };
 		B35F8AED1F36676D00904E37 /* Collection+Changes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Collection+Changes.swift"; path = "Form/Collection+Changes.swift"; sourceTree = "<group>"; };
 		B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionDiffTests.swift; sourceTree = "<group>"; };
@@ -158,7 +160,7 @@
 		F65A9FAA1C7B216F007007B4 /* KeyboardEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeyboardEvent.swift; path = Form/KeyboardEvent.swift; sourceTree = "<group>"; };
 		F65A9FAC1C7B216F007007B4 /* UIEdgeInsets+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIEdgeInsets+Utilities.swift"; path = "Form/UIEdgeInsets+Utilities.swift"; sourceTree = "<group>"; };
 		F666BB8E20BE9741006D2507 /* NumberEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NumberEditor.swift; path = Form/NumberEditor.swift; sourceTree = "<group>"; };
-		F666BBD720BEDC31006D2507 /* FormFramework.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = FormFramework.podspec; sourceTree = "<group>"; };
+		F666BBD720BEDC31006D2507 /* FormFramework.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = FormFramework.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		F666BBD820BEDC32006D2507 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
 		F666BBD920BEDC32006D2507 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		F666BBDA20BEDC32006D2507 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 			children = (
 				F6C2E5E91C69FA0300453548 /* Table.swift */,
 				213A4D2B1D9A633700F0ADE1 /* Reusable.swift */,
+				3156BAEC2139366B00ECC2EC /* MixedReusable.swift */,
 				2191EB5D1D9E9E7800A9B6D0 /* TableKit.swift */,
 				F60102301DAE2D410020015B /* TableChange.swift */,
 				B35F8AED1F36676D00904E37 /* Collection+Changes.swift */,
@@ -573,6 +576,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3156BAED2139366B00ECC2EC /* MixedReusable.swift in Sources */,
 				F684BF0C209349470018EDE9 /* ViewPortEvent.swift in Sources */,
 				F6A0AC4820BC4352000500EC /* CollectionAnimation.swift in Sources */,
 				F6A326E71F9492BC00C3A692 /* FieldStyle.swift in Sources */,

--- a/Form/EitherRow.swift
+++ b/Form/EitherRow.swift
@@ -10,6 +10,7 @@ import UIKit
 import Flow
 
 /// Helper type to provide either a left or right reusable view.
+@available(*, deprecated, message: "Use `Either` type directly instead")
 public struct EitherRow<Left: Reusable, Right: Reusable> where Left.ReuseType: ViewRepresentable, Right.ReuseType: ViewRepresentable {
     public let item: Either<Left, Right>
 
@@ -18,6 +19,7 @@ public struct EitherRow<Left: Reusable, Right: Reusable> where Left.ReuseType: V
     public init(_ right: Right) { item = .right(right) }
 }
 
+@available(*, deprecated, message: "Use `Either` type directly instead")
 extension EitherRow: Reusable {
     public static func makeAndReconfigure() -> (make: UIView, reconfigure: (EitherRow<Left, Right>?, EitherRow<Left, Right>) -> Disposable) {
         let row = UIStackView()

--- a/Form/MixedReusable.swift
+++ b/Form/MixedReusable.swift
@@ -10,7 +10,7 @@ import Foundation
 import Flow
 
 /// Helper containter for creating e.g. `Table`s of mixed content.
-/// In comparison of using e.g. `Either`, `MixedReusable` will loose type information
+/// In comparison of using e.g. `Either`, `MixedReusable` will lose type information
 /// as it will hold its value as `Any`.
 ///
 ///     var mixedTable = Table<(), MixedReusable>(rows: [.init(1), .init("A"), .init("B"), .init(2)])

--- a/Form/MixedReusable.swift
+++ b/Form/MixedReusable.swift
@@ -1,0 +1,72 @@
+//
+//  MixedReusable.swift
+//  Form
+//
+//  Created by Måns Bernhardt on 2018-08-31.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import Foundation
+import Flow
+
+/// Helper containter for creating e.g. `Table`s of mixed content.
+/// In comparison of using e.g. `Either`, `MixedReusable` will loose type information
+/// as it will hold its value as `Any`.
+///
+///     var mixedTable = Table<(), MixedReusable>(rows: [.init(1), .init("A"), .init("B"), .init(2)])
+///
+/// - Note: It is often preferable to use e.g. `Either` to not loose types.
+public struct MixedReusable {
+    private typealias ViewAndReconfigure = (view: UIView, reconfigure: (Any?, Any) -> Disposable)
+    private let viewAndReconfigure: () -> ViewAndReconfigure
+    let identifier: (Any) -> AnyHashable
+    let isSameAs: (Any) -> Bool
+
+    public let value: Any
+    public let reuseIdentifier: String
+
+    /// Creates a new instance holding `value`
+    ///   - identifier: Closure returning unique identity for a given value
+    ///   - isSame: Closure indicating whether two values are equal.
+    public init<Value: Reusable>(_ value: Value, identifier: @escaping (Value) -> AnyHashable, isSame: @escaping (Value, Value) -> Bool) where Value.ReuseType: ViewRepresentable {
+        self.value = value
+        self.identifier = { identifier($0 as! Value) }
+        self.isSameAs = { isSame(value, $0 as! Value) }
+        self.reuseIdentifier = String(describing: type(of: Value.self))
+        self.viewAndReconfigure = {
+            let (reuseType, reconfigure) = Value.makeAndReconfigure()
+            return (reuseType.viewRepresentation, { reconfigure($0 as! Value?, $1 as! Value) })
+        }
+    }
+}
+
+extension MixedReusable: Reusable {
+    public static func makeAndReconfigure() -> (make: UIView, reconfigure: (MixedReusable?, MixedReusable) -> Disposable) {
+        let row = UIStackView()
+        var viewAndReconfigure: ViewAndReconfigure?
+        return (row, { prev, mixed in
+            if viewAndReconfigure == nil {
+                viewAndReconfigure = mixed.viewAndReconfigure()
+                row.orderedViews = [viewAndReconfigure!.view]
+            }
+            return viewAndReconfigure!.reconfigure(prev?.value, mixed.value)
+        })
+    }
+}
+
+extension MixedReusable {
+    /// Creates a new instance holding `value`
+    public init<Value: Reusable & Hashable>(_ value: Value) where Value.ReuseType: ViewRepresentable {
+        self.init(value, identifier: { $0 }, isSame: ==)
+    }
+}
+
+extension MixedReusable: Hashable {
+    public var hashValue: Int {
+        return identifier(value).hashValue
+    }
+
+    public static func == (lhs: MixedReusable, rhs: MixedReusable) -> Bool {
+        return lhs.reuseIdentifier == rhs.reuseIdentifier && lhs.hashValue == rhs.hashValue && lhs.isSameAs(rhs.value)
+    }
+}

--- a/Form/Reusable.swift
+++ b/Form/Reusable.swift
@@ -53,6 +53,10 @@ public protocol Reusable {
     ///     }
     /// - Note: Only one of `makeAndConfigure()` or `makeAndReconfigure()` should be implemented.
     static func makeAndReconfigure() -> (make: ReuseType, reconfigure: (_ preceding: Self?, _ current: Self) -> Disposable)
+
+    /// The reuseIdentifer to be used when `Self` is used with e.g. `UITableView`'s or `UICollectionView`'s
+    /// Has a default implementation to return the name of `Self`'s type that should be suitable for most conforming types.
+    var reuseIdentifier: String { get }
 }
 
 public extension Reusable {
@@ -84,5 +88,61 @@ public extension Reusable {
 
     func reuseType() -> ReuseType {
         return reuseTypeAndDisposable().make
+    }
+
+    var reuseIdentifier: String {
+        return String(describing: Self.self)
+    }
+}
+
+/// You can use `Either`'s conditional conformance to `Reusable` to create `Table`s of mixed content.
+///
+///     typealias Row = Either<Int, String>
+///     let table = Table<(), Row>(rows: [.left(1), .right("A")]
+///
+///     typealias Row = Either<Either<Int, String>, Double>
+///     let table = Table<(), Row>(rows: [.left(.left(1)), .left(.right("A")), .right(3.14)]]
+///
+/// - See also: MixedReusable
+extension Either: Reusable where Left: Reusable, Right: Reusable, Left.ReuseType: ViewRepresentable, Right.ReuseType: ViewRepresentable {
+    public typealias ReuseType = UIView
+    private typealias ViewAndReconfigure<T: Reusable> = (make: T.ReuseType, reconfigure: (T?, T) -> Disposable)
+
+    public static func makeAndReconfigure() -> (make: UIView, reconfigure: (Either?, Either) -> Disposable) {
+        let row = UIStackView()
+        var left: ViewAndReconfigure<Left>!
+        var right: ViewAndReconfigure<Right>!
+
+        return (row, { prev, item in
+            if left == nil && right == nil {
+                switch item {
+                case .left:
+                    left = Left.makeAndReconfigure()
+                    row.orderedViews = [left.make.viewRepresentation]
+                case .right:
+                    right = Right.makeAndReconfigure()
+                    row.orderedViews = [right.make.viewRepresentation]
+                }
+            }
+            switch (prev, item) {
+            case (nil, .left(let item)):
+                return left.reconfigure(nil, item)
+            case (.left(let prev)?, .left(let item)):
+                return left.reconfigure(prev, item)
+            case (nil, .right(let item)):
+                return right.reconfigure(nil, item)
+            case (.right(let prev)?, .right(let item)):
+                return right.reconfigure(prev, item)
+            default:
+                fatalError("Should never get here")
+            }
+        })
+    }
+
+    public var reuseIdentifier: String {
+        switch self {
+        case .left(let l): return l.reuseIdentifier
+        case .right(let r): return r.reuseIdentifier
+        }
     }
 }

--- a/Form/Reusable.swift
+++ b/Form/Reusable.swift
@@ -134,7 +134,8 @@ extension Either: Reusable where Left: Reusable, Right: Reusable, Left.ReuseType
             case (.right(let prev)?, .right(let item)):
                 return right.reconfigure(prev, item)
             default:
-                fatalError("Should never get here")
+                assertionFailure("We should never get a mix of left and right for prev and item")
+                return NilDisposer()
             }
         })
     }

--- a/Form/UICollectionViewCell+Utilities.swift
+++ b/Form/UICollectionViewCell+Utilities.swift
@@ -18,14 +18,13 @@ public extension UICollectionView {
 
     /// Dequeues (reuses) or creates a new cell for `indexPath`.
     /// - Parameter item: The item used to configure the cell.
-    /// - Parameter reuseIdentifier: The reuse identifier for the cell, defaults to `#function`.
+    /// - Parameter reuseIdentifier: The reuse identifier for the cell, defaults to name of `Item`'s type.
     /// - Parameter contentViewAndConfigure: A closure when given a reuse identifier returns a tuple of a view and a configure closure.
     ///     The configure closure passes the item to be used to configure the cell.
     ///     The disposable returned from the configure closure will be disposed before reusage.
     /// - Returns: A cell with the view embedded in.
     /// - Note: See `Reusable` for more info about reconfigure.
-    func dequeueCell<Item>(forItem item: Item, at indexPath: IndexPath, contentViewAndConfigure: () -> (UIView, (Item) -> Disposable)) -> UICollectionViewCell {
-        let reuseIdentifier = String(describing: Item.self)
+    func dequeueCell<Item>(forItem item: Item, at indexPath: IndexPath, reuseIdentifier: String = String(describing: Item.self), contentViewAndConfigure: () -> (UIView, (Item) -> Disposable)) -> UICollectionViewCell {
 
         register(UICollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
 
@@ -46,7 +45,7 @@ public extension UICollectionView {
 
     /// Dequeues (reuses) or creates a new view and using the `item`'s conformance to `Reusable` to create and configure the view to embed in the returned cell.
     func dequeueCell<Item: Reusable>(forItem item: Item, at indexPath: IndexPath) -> UICollectionViewCell where Item.ReuseType: ViewRepresentable {
-        return dequeueCell(forItem: item, at: indexPath, contentViewAndConfigure: {
+        return dequeueCell(forItem: item, at: indexPath, reuseIdentifier: item.reuseIdentifier, contentViewAndConfigure: {
             let (viewRepresentable, configure) = Item.makeAndConfigure()
             return (viewRepresentable.viewRepresentation, configure)
         })


### PR DESCRIPTION
- Added `reuseIdentifier` to the `Reusable ` protocol to allow better handling of tables with mixed types.

- Added `Either` conditional conformance to `Reusable` when `Left` and `Right` conforms to `Reusable`.
- Added alternative helper type `MixedReusable` that can be used instead of `Either` for tables with mixed types.
- Extended the Demo sample with examples show-casing using tables with mixed types.

- Deprecating `EitherRow`, replaced by using Flows `Either` instead
- Deprecating `dequeueCell(forItem:, style:, reuseIdentifier:)`, replaced by version not using explicit `reuseIdentifier`