### PR TITLE
Remove MixedReusable conformance to Equatable/Hashable

### DIFF
--- a/Examples/Demo/Example/Tables.swift
+++ b/Examples/Demo/Example/Tables.swift
@@ -220,13 +220,3 @@ extension Double: Reusable {
         })
     }
 }
-
-// Could be removed once this is added to Flow
-extension Either: Hashable where Left: Hashable, Right: Hashable {
-    public var hashValue: Int {
-        switch self {
-        case .left(let left): return left.hashValue
-        case .right(let right): return right.hashValue
-        }
-    }
-}

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { 'iZettle AB' => 'hello@izettle.com' }
 
   s.ios.deployment_target = "9.0"
-  s.dependency 'FlowFramework', '~> 1.2'
+  s.dependency 'FlowFramework', '~> 1.2.1'
   s.default_subspec = 'Form'
 
   s.subspec 'Form' do |form|


### PR DESCRIPTION
- Removed MixedReusable conformance to Equatable/Hashable that was added for convenience when animating updates using TableAnimatable.
- MixedReusable conformance to Equatable/Hashable is not correct. Instead we `set` overloads to TableAnimatable
- Updated pod spec to require Flow 1.2.1 to get new Either: Hashable conformance.
