### PR TITLE
Use UITableViewAutomaticDimension instead of hardcoded height value

### DIFF
--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -130,8 +130,8 @@ public final class TableKit<Section, Row> {
 
             view.sectionHeaderHeight = UITableViewAutomaticDimension
             view.sectionFooterHeight = UITableViewAutomaticDimension
-            view.estimatedSectionHeaderHeight = style.fixedHeaderHeight ?? 32
-            view.estimatedSectionFooterHeight = style.fixedFooterHeight ?? 32
+            view.estimatedSectionHeaderHeight = style.fixedHeaderHeight ?? UITableViewAutomaticDimension
+            view.estimatedSectionFooterHeight = style.fixedFooterHeight ?? UITableViewAutomaticDimension
 
             if view.autoResizingTableHeaderView === tableHeader {
                tableHeaderConstraint.constant = style.form.insets.top


### PR DESCRIPTION
Using a hardcoded value causes a crash on iOS 9 (trying to find an example that reproduces it) when the header/footer size changes during table view update.

I'm sure there is a reason why 32 was used but we missed to add a comment to it.. does anyone know why it was used? 

We need to test well the example apps to check that this doesn't affect their headers and hopefully find an example that causes the crash. 