### PR TITLE
Remove TableKit and CollectionKit private Table

### DIFF
--- a/Form/CollectionKit.swift
+++ b/Form/CollectionKit.swift
@@ -16,7 +16,6 @@ import Flow
 public final class CollectionKit<Section, Row> {
     private let callbacker = Callbacker<Table>()
     private let changesCallbacker = Callbacker<[TableChange<Section, Row>]>()
-    private var _table: Table
 
     public typealias Table = Form.Table<Section, Row>
 
@@ -27,9 +26,8 @@ public final class CollectionKit<Section, Row> {
     // swiftlint:enable weak_delegate
 
     public var table: Table {
-        get { return _table }
+        get { return dataSource.table }
         set {
-            _table = newValue
             dataSource.table = table
             delegate.table = table
             view.reloadData()
@@ -43,7 +41,6 @@ public final class CollectionKit<Section, Row> {
     ///   - bag: A bag used to add collection kit activities.
     public init(table: Table = Table(), layout: UICollectionViewLayout, bag: DisposeBag, cellForRow: @escaping (UICollectionView, Row, TableIndex) -> UICollectionViewCell) {
         self.view = UICollectionView.defaultCollection(withLayout: layout)
-        _table = table
 
         dataSource.table = table
         delegate.table = table
@@ -96,7 +93,6 @@ extension CollectionKit: TableAnimatable {
                                                                           rowIdentifier: (Row) -> RowIdentifier,
                                                                           rowNeedsUpdate: ((Row, Row) -> Bool)?) {
         let from = self.table
-        _table = table
 
         delegate.table = table
         dataSource.table = table

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -16,7 +16,6 @@ import Flow
 public final class TableKit<Section, Row> {
     private let callbacker = Callbacker<Table>()
     private let changesCallbacker = Callbacker<[TableChange<Section, Row>]>()
-    private var _table: Table
 
     public typealias Table = Form.Table<Section, Row>
 
@@ -28,9 +27,8 @@ public final class TableKit<Section, Row> {
     public let style: DynamicTableViewFormStyle
 
     public var table: Table {
-        get { return _table }
+        get { return dataSource.table }
         set {
-            _table = newValue
             dataSource.table = table
             delegate.table = table
             view.reloadData()
@@ -95,7 +93,6 @@ public final class TableKit<Section, Row> {
         let view = view ?? UITableView.defaultTable(for: style.tableStyle)
         self.view = view
         self.style = style
-        _table = table
 
         dataSource.table = table
         delegate.table = table
@@ -279,7 +276,6 @@ extension TableKit: TableAnimatable {
                                                                           rowNeedsUpdate: ((Row, Row) -> Bool)? = { _, _ in true }) {
 
         let from = self.table
-        _table = table
         dataSource.table = table
         delegate.table = table
 


### PR DESCRIPTION
Make datasource's table the source of truth in `TableKit` and `CollectionKit`

## Motivation
First `private var _table: Table` was not really used in either `TableKit` or `CollectionKit`. Secondly, having a private table makes `TableKit` or `CollectionKit` closed from extension. We can imagine users of `Form` wanting to add new features to manipulate the Table
