### PR TITLE
Bumped version to 1.3.0 and updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3
+
+- Added reordering delegate `reordering` to `CollectionViewDelegate`.
+- Added `apply(changes:)` to `MutableCollection`, `TableKit` and `CollectionKit`.
+
+- Fixed a `TableKit` crash on iOS 9.
+- Fixed a compiler "unable to type-check this expression in reasonable time" on Swift 4.2.
+
 ## 1.2
 
 - Added `reuseIdentifier` to the `Reusable` protocol to allow better handling of tables with mixed types.

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.2.0"
+  s.version      = "1.3.0"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC


### PR DESCRIPTION
## 1.3

- Added reordering delegate `reordering` to `CollectionViewDelegate`.
- Added `apply(changes:)` to `MutableCollection`, `TableKit` and `CollectionKit`.

- Fixed a `TableKit` crash on iOS 9.
- Fixed a compiler "unable to type-check this expression in reasonable time" on Swift 4.2.
