### PR TITLE
Don't change text color on highlight if highlightedColor is not set explicitly

### DIFF
--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -66,7 +66,7 @@ public extension TextStyle {
     }
 
     var highlightedColor: UIColor {
-        get { return attribute(for: .highlightedColor) ?? .black }
+        get { return attribute(for: .highlightedColor) ?? self.color }
         set { setAttribute(newValue, for: .highlightedColor) }
     }
 }


### PR DESCRIPTION
It is better to default to the text color instead of black if highlightedColor is not set explicitly.