### PR TITLE
Fix update change index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.2
+
+- Bugfix: Fixed issue where update indices in `TableChange` and `ChangeStep` were specified in the new array rather than the orignal array
+- Bugfix: Fixed crash in UICollectoinView when animating section and row changes at the same time
+
 ## 1.3.1
 
 - Bugfix: Fixed issue where out of range `UIViewAnimationCurve` enum values caused a crash running on Xcode 10 and iOS 12.

--- a/Form/Collection+Changes.swift
+++ b/Form/Collection+Changes.swift
@@ -204,7 +204,7 @@ extension Collection where Index == Int {
                 if (oldIndex - deleteOffset + runningOffset) != index {
                     steps.append(.move(item: other[index], from: oldIndex, to: index))
                 } else if needsUpdate(self[oldIndex], other[index]) {
-                    steps.append(.update(item: other[index], at: index))
+                    steps.append(.update(item: other[index], at: oldIndex))
                 }
             }
         }
@@ -293,8 +293,8 @@ private extension Collection {
         deletions.sort { $0.index > $1.index }
         insertions.sort { $0.index < $1.index }
 
-        // Deletes are processed before inserts in batch operations. This means the indexes for the deletions are processed relative to the indexes of the collection view’s state before the batch operation, and the indexes for the insertions are processed relative to the indexes of the state after all the deletions in the batch operation.
-        let sortedChanges = deletions + insertions + updates
+        // Deletes and Updates are processed before inserts in batch operations. This means the indexes for the deletions are processed relative to the indexes of the collection view’s state before the batch operation, and the indexes for the insertions are processed relative to the indexes of the state after all the deletions in the batch operation.
+        let sortedChanges = updates + deletions + insertions
         return sortedChanges
     }
 }

--- a/Form/CollectionAnimation.swift
+++ b/Form/CollectionAnimation.swift
@@ -24,7 +24,7 @@ public extension UICollectionView {
     func animate<Section, Row>(changes: [TableChange<Section, Row>], animation: CollectionAnimation = .default) {
         guard !changes.isEmpty else { return }
 
-        guard animation != .none, window != nil else {
+        guard animation != .none, window != nil, canAnimateUpdates(with: changes) else {
             reloadData()
             return
         }
@@ -61,5 +61,20 @@ public extension UICollectionView {
             }
 
         }, completion: nil)
+    }
+}
+
+private extension UICollectionView {
+    func canAnimateUpdates<Section, Row>(with changes: [TableChange<Section, Row>]) -> Bool {
+        for change in changes {
+            switch change {
+            case .section(.insert), .section(.delete), .section(.move):
+                // Disabling animation if the sections are changing since this leads to crashes when combined with row changes in those sections
+                return false
+            default:
+                continue
+            }
+        }
+        return true
     }
 }

--- a/Form/TableChange.swift
+++ b/Form/TableChange.swift
@@ -152,8 +152,8 @@ private extension Collection {
             }
         }
 
-        // Deletes are processed before inserts in batch operations. This means the indexes for the deletions are processed relative to the indexes of the collection view’s state before the batch operation, and the indexes for the insertions are processed relative to the indexes of the state after all the deletions in the batch operation.
-        let sortedChanges = deletions + insertions + updates
+        // Deletes and Updates are processed before inserts in batch operations. This means the indexes for the deletions are processed relative to the indexes of the collection view’s state before the batch operation, and the indexes for the insertions are processed relative to the indexes of the state after all the deletions in the batch operation.
+        let sortedChanges = updates + deletions + insertions
         return sortedChanges
     }
 }

--- a/FormTests/CollectionDiffTests.swift
+++ b/FormTests/CollectionDiffTests.swift
@@ -98,12 +98,44 @@ class DiffTests: XCTestCase {
 
     func testMovesAndUpdatesDontCollide() {
         let old = [TestRow(identifier: 0, value: "0"), TestRow(identifier: 1, value: "1"), TestRow(identifier: 2, value: "2")]
-        let new = [TestRow(identifier: 0, value: "0"), TestRow(identifier: 2, value: "3"), TestRow(identifier: 1, value: "4")]
+        let new = [TestRow(identifier: 0, value: "0"), TestRow(identifier: 2, value: "2'"), TestRow(identifier: 1, value: "1'")]
 
         let changes = old.notFullyOrderedChanges(toBuild: new, identifier: { $0.identifier }, needsUpdate: !=)
         for change in changes {
             if case .update = change { XCTAssertTrue(false, "There should not be moves and updates at the same index") }
         }
+
+        var newArray = old
+        newArray.apply(changes)
+        XCTAssertEqual(newArray, new)
+    }
+
+    func testUpdatesSpecifiedInTheOriginalTable() {
+        let old = [TestRow(identifier: 0, value: "0"), TestRow(identifier: 1, value: "1"), TestRow(identifier: 2, value: "2")]
+        let new = [TestRow(identifier: 0, value: "0"), TestRow(identifier: 2, value: "2'")]
+
+        let changes = old.notFullyOrderedChanges(toBuild: new, identifier: { $0.identifier }, needsUpdate: !=)
+        let updates = changes.compactMap { change -> Int? in
+            guard case let .update(item: _, at: index) = change else { return nil }
+            return index
+        }
+        XCTAssertEqual(updates, [2])
+
+        var newArray = old
+        newArray.apply(changes)
+        XCTAssertEqual(newArray, new)
+    }
+
+    func testInsertsWithUpdatesSpecifiedInTheOriginalTable() {
+        let old = [TestRow(identifier: 0, value: "0"), TestRow(identifier: 1, value: "1"), TestRow(identifier: 2, value: "2")]
+        let new = [TestRow(identifier: 0, value: "0"), TestRow(identifier: 3, value: "3"), TestRow(identifier: 1, value: "1"), TestRow(identifier: 2, value: "2'")]
+
+        let changes = old.notFullyOrderedChanges(toBuild: new, identifier: { $0.identifier }, needsUpdate: !=)
+        let updates = changes.compactMap { change -> Int? in
+            guard case let .update(item: _, at: index) = change else { return nil }
+            return index
+        }
+        XCTAssertEqual(updates, [2])
 
         var newArray = old
         newArray.apply(changes)


### PR DESCRIPTION
The updates indices in the changes are not correct. The index should be specified in the original array as specified in [Apple documentation](https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9):

> Deletion and *reloading* operations within an animation block specify which rows and sections in the *original table* should be removed or reloaded; insertions specify which rows and sections should be added to the resulting table. The index paths used to identify sections and rows follow this model. Inserting or removing an item in a mutable array, on the other hand, may affect the array index used for the successive insertion or removal operation; for example, if you insert an item at a certain index, the indexes of all subsequent items in the array are incremented.

We never found this issue before, because in `TableAnimation` the updates are not performed in the batch update. But in `CollectionAnimation` they are and it crashes today

I also updated the TableChangeTests to include tests for the collection view. The current tests were also not testing anything because the table view has no size and was not going through a layout pass.
I also disabled the animations in the CollectionView in case of section changes since it is crashing when combined with row updates