### PR TITLE
Updated dependencies on Flow and Form to be at least `>=` instead of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.3
+
+ - Updated dependencies on Flow and Form to be at least `>=` instead of compatiblie with version `~=`.
+
 ## 1.3.2
 
 - Bugfix: Fixed issue where update indices in `TableChange` and `ChangeStep` were specified in the new array rather than the orignal array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.3.3
 
- - Updated dependencies on Flow and Form to be at least `>=` instead of compatiblie with version `~=`.
+ - Updated dependencies on Flow and Form to be at least `>=` instead of compatible with version `~=`.
 
 ## 1.3.2
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "iZettle/Flow" ~> 1.3
+github "iZettle/Flow" >= 1.3

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.3.2"
+  s.version      = "1.3.3"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { 'iZettle AB' => 'hello@izettle.com' }
 
   s.ios.deployment_target = "9.0"
-  s.dependency 'FlowFramework', '~> 1.3'
+  s.dependency 'FlowFramework', '>= 1.3'
   s.default_subspec = 'Form'
 
   s.subspec 'Form' do |form|
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Presentation' do |presentation|
-    presentation.dependency 'PresentationFramework', '~> 1.1'
+    presentation.dependency 'PresentationFramework', '>= 1.1'
   end
 
   s.source       = { :git => "https://github.com/iZettle/Form.git", :tag => "#{s.version}" }


### PR DESCRIPTION
…compatiblie with version `~=`.