### PR TITLE
Remove hardcoded value used for determing smallest resizable image size

### DIFF
--- a/Form/UIImage+Styling.swift
+++ b/Form/UIImage+Styling.swift
@@ -64,8 +64,8 @@ extension UIImage {
         let ceiledTopSeparatorHeight = ceil(topSeparatorHeight)
 
         // Computing the smallest rect possible to draw this image
-        let rectWidth = max(cornerRadius + ceiledBorderWidths.left, bottomSeparatorInsets.left, topSeparatorInsets.left) + max(cornerRadius + ceiledBorderWidths.right, bottomSeparatorInsets.right, topSeparatorInsets.right)
-        let rectHeight = max(cornerRadius + ceiledBorderWidths.top, ceiledSeparatorHeight) + max(cornerRadius + ceiledBorderWidths.bottom, ceiledTopSeparatorHeight)
+        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
+        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
         let rect = CGRect(x: 0, y: 0, width: max(1, rectWidth), height: max(1, rectHeight))
 
         let isOpaque: Bool

--- a/Form/UIImage+Styling.swift
+++ b/Form/UIImage+Styling.swift
@@ -64,11 +64,9 @@ extension UIImage {
         let ceiledTopSeparatorHeight = ceil(topSeparatorHeight)
 
         // Computing the smallest rect possible to draw this image
-        let stretchableSize: CGFloat = cornerRadius >= 8 ? 0 : 1 // From a radius of curvature of 8px it seems that the line next to the border is straight enough to be sretched to a line, so no need for an additional 1px
-        let rectWidth = stretchableSize + max(max(cornerRadius, ceiledBorderWidths.left), bottomSeparatorInsets.left, topSeparatorInsets.left) + max(max(cornerRadius, ceiledBorderWidths.right), bottomSeparatorInsets.right, topSeparatorInsets.right)
-        let rectHeight = stretchableSize + max(max(cornerRadius, ceiledBorderWidths.top), ceiledSeparatorHeight) + max(max(cornerRadius, ceiledBorderWidths.bottom), ceiledTopSeparatorHeight)
-
-        let rect = CGRect(x: 0, y: 0, width: rectWidth, height: rectHeight)
+        let rectWidth = max(cornerRadius + ceiledBorderWidths.left, bottomSeparatorInsets.left, topSeparatorInsets.left) + max(cornerRadius + ceiledBorderWidths.right, bottomSeparatorInsets.right, topSeparatorInsets.right)
+        let rectHeight = max(cornerRadius + ceiledBorderWidths.top, ceiledSeparatorHeight) + max(cornerRadius + ceiledBorderWidths.bottom, ceiledTopSeparatorHeight)
+        let rect = CGRect(x: 0, y: 0, width: max(1, rectWidth), height: max(1, rectHeight))
 
         let isOpaque: Bool
         switch (position, cornerRadius != 0, background.isOpaque) {


### PR DESCRIPTION
I didn't fully get the idea of `let stretchableSize: CGFloat = cornerRadius >= 8 ? 0 : 1` but these are some images with different values before/after:

Before:

stretchableSize = 1, border 1.5 (very tiny glitch around the corners):
![stretchablesize_1](https://user-images.githubusercontent.com/1555713/46793880-f9f83c00-cd46-11e8-9c78-c3f766936e36.png)

stretchableSize = 0, border 1.5:
![stretchablesize_0](https://user-images.githubusercontent.com/1555713/46793878-f9f83c00-cd46-11e8-9476-4e8425e2177d.png)

stretchableSize = 1, border 6:
![stretchablesize_1_border6](https://user-images.githubusercontent.com/1555713/46793879-f9f83c00-cd46-11e8-8d53-7e3b09823acd.png)

stretchableSize = 0, border 6:
![stretchablesize_0_border6](https://user-images.githubusercontent.com/1555713/46793877-f9f83c00-cd46-11e8-82f0-d5ac32cd2493.png)

After:

border: 1.5
![no_stretchablesize](https://user-images.githubusercontent.com/1555713/46793876-f95fa580-cd46-11e8-81bd-443fdadfed55.png)

border: 6
![no_stretchablesize_border6](https://user-images.githubusercontent.com/1555713/46793875-f95fa580-cd46-11e8-9d82-38df567b439c.png)

I will try to check few images with separators too.