### PR TITLE
Fix a bug where highligted segment turns gray if it's also selected

### DIFF
--- a/Form/ButtonStateStyle.swift
+++ b/Form/ButtonStateStyle.swift
@@ -54,7 +54,8 @@ public extension UIBarMetrics {
 }
 
 public extension UIControlState {
-    static let standardStates: [UIControlState] = [.normal, .highlighted, .disabled, .selected]
+    static let selectedAndHighlighted: UIControlState = [.selected, .highlighted]
+    static let standardStates: [UIControlState] = [.normal, .highlighted, .disabled, .selected, selectedAndHighlighted]
     static let standardStatesNoSelected: [UIControlState] = [.normal, .highlighted, .disabled]
 }
 
@@ -65,6 +66,7 @@ public extension Dictionary where Key == UIControlState {
         self[.highlighted] = highlighted
         self[.disabled] = disabled
         self[.selected] = selected
+        self[.selectedAndHighlighted] = highlighted ?? selected
     }
 }
 


### PR DESCRIPTION
If a segmented control is missing the state for selected and highlighted at the same time, then it will turn gray no matter if the background images for selected and highlighted states are set properly.

From our Demo example app:
![segmeted-control-bug](https://user-images.githubusercontent.com/1555713/46918798-dcd99c80-cfd6-11e8-9562-e78e2d1012d7.gif)


The aim of this PR is to prevent this bug from happening. I decided to go with reusing the already provided background images:

![segmented-control-bug-fix](https://user-images.githubusercontent.com/1555713/46918801-ec58e580-cfd6-11e8-8e65-ed42ed0b39a6.gif)