### PR TITLE
Add extra space to the resizable image rect to prevent the border taking the whole image

### DIFF
--- a/Form/UIImage+Styling.swift
+++ b/Form/UIImage+Styling.swift
@@ -63,9 +63,9 @@ extension UIImage {
         let ceiledSeparatorHeight = ceil(bottomSeparatorHeight)
         let ceiledTopSeparatorHeight = ceil(topSeparatorHeight)
 
-        // Computing the smallest rect possible to draw this image
-        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
-        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
+        // Computing the smallest rect possible to draw this image - note that it should be slightly bigger than the border widths so that it draws a stretchable non-solid area too
+        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + .thinestLineWidth + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
+        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + .thinestLineWidth + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
         let rect = CGRect(x: 0, y: 0, width: max(1, rectWidth), height: max(1, rectHeight))
 
         let isOpaque: Bool


### PR DESCRIPTION
If we create an image without corner radius with a border, the smallest generated image should include the border and a bit of extra space. That way when resized, the image will have a transparent area that will be stretched instead of having solid background with the border color.

Basically in this test:
```swift
let borderStyle = BorderStyle(width: 3, color: .blue, borderEdges: .bottom)
let backgroundStyle = BackgroundStyle(color: .white, border: borderStyle)
let imageView = UIImageView(image: UIImage(style: backgroundStyle))
imageView.frame = CGRect(origin: .zero, size: CGSize(square: 100))
FBSnapshotVerifyView(imageView)
```
I was getting this:

![testborder_bottom_failing](https://user-images.githubusercontent.com/1555713/47027237-628c5200-d167-11e8-95de-4e05586bcc03.png)

instead of this:

![testborder_bottom](https://user-images.githubusercontent.com/1555713/47027240-64561580-d167-11e8-842c-b2feb5d97448.png)