### PR TITLE
Bump version to 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.3
+- Bugfix: Remove hardcoded value used for determing smallest resizable image size causing not smooth borders of rounded images
+- Bugfix: Fix a bug where highligted segment turns gray if it's also selected
+- Bugfix: Add extra space to the resizable image rect to prevent the border taking the whole image
+
 ## 1.3.2
 
 - Bugfix: Fixed issue where update indices in `TableChange` and `ChangeStep` were specified in the new array rather than the orignal array

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.3.2"
+  s.version      = "1.3.3"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- Bugfix: Remove hardcoded value used for determing smallest resizable image size causing not smooth borders of rounded images
- Bugfix: Fix a bug where highligted segment turns gray if it's also selected
- Bugfix: Add extra space to the resizable image rect to prevent the border taking the whole image