### PR TITLE
TextFieldDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4
+
+- Added `TextFieldDelegate` similar to `ScrollViewDelegate` and friends.
+- Added `UITextField` and `UIScrollView` `install()` delegate helpers.
+
 ## 1.3.3
 - Bugfix: Remove hardcoded value used for determing smallest resizable image size causing not smooth borders of rounded images
 - Bugfix: Fix a bug where highligted segment turns gray if it's also selected

--- a/Examples/Demo/Example/Contents.swift
+++ b/Examples/Demo/Example/Contents.swift
@@ -40,7 +40,13 @@ extension UIViewController {
         let label = UILabel(value: "Hello")
         stylingSection.appendRow(title: "Label").append(label)
 
-        let textRow = stylingSection.appendRow(title: "TextField").append(UITextField(value: "Hello", placeholder: "PlaceHolder"))
+        let textField = UITextField(value: "Hello", placeholder: "PlaceHolder")
+        let textDelegate = TextFieldDelegate()
+        bag += textField.install(textDelegate)
+
+        bag += textDelegate.shouldChangeToProposedText.set { $0.count < 10 }
+
+        let textRow = stylingSection.appendRow(title: "TextField").append(textField)
         bag += textRow.atOnce().map { $0 }.bindTo(label, \.value)
 
         let buttonRow = stylingSection.appendRow(title: "Button").append(UIButton(title: "Hello"))

--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		F6A326EA1F94935200C3A692 /* UILabel+Styling.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A326E91F94935200C3A692 /* UILabel+Styling.swift */; };
 		F6A326EC1F9493B200C3A692 /* TextStyle+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A326EB1F9493B200C3A692 /* TextStyle+Utilities.swift */; };
 		F6B143341FCC3FA900B63D0F /* Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B143331FCC3FA900B63D0F /* Constraints.swift */; };
+		F6B66F6F2177786C0072FAB5 /* TextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B66F6E2177786B0072FAB5 /* TextFieldDelegate.swift */; };
 		F6B81B9420CA906000B6AC39 /* NumberEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B81B9320CA906000B6AC39 /* NumberEditorTests.swift */; };
 		F6BFAFA72090719F00CBA6B1 /* UITextField+Styling.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFAFA62090719F00CBA6B1 /* UITextField+Styling.swift */; };
 		F6BFAFAD2090746C00CBA6B1 /* BarButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFAFAC2090746C00CBA6B1 /* BarButtonStyle.swift */; };
@@ -190,6 +191,7 @@
 		F6A326EB1F9493B200C3A692 /* TextStyle+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "TextStyle+Utilities.swift"; path = "Form/TextStyle+Utilities.swift"; sourceTree = "<group>"; };
 		F6A9D5DE1C1728BA009A0EEB /* Form.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Form.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6B143331FCC3FA900B63D0F /* Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constraints.swift; path = Form/Constraints.swift; sourceTree = "<group>"; };
+		F6B66F6E2177786B0072FAB5 /* TextFieldDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextFieldDelegate.swift; path = Form/TextFieldDelegate.swift; sourceTree = "<group>"; };
 		F6B81B9320CA906000B6AC39 /* NumberEditorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberEditorTests.swift; sourceTree = "<group>"; };
 		F6BFAFA62090719F00CBA6B1 /* UITextField+Styling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITextField+Styling.swift"; path = "Form/UITextField+Styling.swift"; sourceTree = "<group>"; };
 		F6BFAFAC2090746C00CBA6B1 /* BarButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BarButtonStyle.swift; path = Form/BarButtonStyle.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 				F67D378D1C7B2EDD00A35BD4 /* TextEditor.swift */,
 				F684BF17209350B60018EDE9 /* ValueEditor.swift */,
 				F666BB8E20BE9741006D2507 /* NumberEditor.swift */,
+				F6B66F6E2177786B0072FAB5 /* TextFieldDelegate.swift */,
 			);
 			name = Values;
 			sourceTree = "<group>";
@@ -597,6 +600,7 @@
 				F63863122090B73F00A43824 /* RowView.swift in Sources */,
 				F65A9FB21C7B216F007007B4 /* UIEdgeInsets+Utilities.swift in Sources */,
 				21A79B6D1DBF5D84000D1231 /* BackgroundStyle.swift in Sources */,
+				F6B66F6F2177786C0072FAB5 /* TextFieldDelegate.swift in Sources */,
 				F6DC567F208F464100F2DF3C /* BorderStyle.swift in Sources */,
 				F684BF18209350B60018EDE9 /* ValueEditor.swift in Sources */,
 				F66835D62091CC32002D2676 /* UIResponders+Utilities.swift in Sources */,

--- a/Form/ScrollViewDelegate.swift
+++ b/Form/ScrollViewDelegate.swift
@@ -54,3 +54,13 @@ public extension ScrollViewDelegate {
         return Signal(callbacker: willBeginDraggingCallbacker)
     }
 }
+
+public extension UIScrollView {
+    func install(_ delegate: UIScrollViewDelegate) -> Disposable {
+        self.delegate = delegate
+        return Disposer {
+            _ = delegate // Hold on to
+            self.delegate = nil
+        }
+    }
+}

--- a/Form/TextFieldDelegate.swift
+++ b/Form/TextFieldDelegate.swift
@@ -1,0 +1,72 @@
+//
+//  TextFieldDelegate.swift
+//  Form
+//
+//  Created by Måns Bernhardt on 2018-10-17.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import Flow
+import UIKit
+
+public final class TextFieldDelegate: NSObject, UITextFieldDelegate {
+    private var didEndEditingCallbacker = Callbacker<()>()
+
+    public var shouldBeginEditing = Delegate<String, Bool>()
+    public var shouldEndEditing = Delegate<String, Bool>()
+    public var shouldChangeCharacters = Delegate<(current: String, range: Range<String.Index>, replacementString: String), Bool>()
+    public var shouldReturn = Delegate<String, Bool>()
+    public var shouldClear = Delegate<String, Bool>()
+
+    public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        return shouldBeginEditing.call(textField.value) ?? true
+    }
+
+    public func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        return shouldEndEditing.call(textField.value) ?? true
+    }
+
+    public func textFieldDidEndEditing(_ textField: UITextField) {
+        didEndEditingCallbacker.callAll()
+    }
+
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let range = Range(range, in: textField.value) else { return true }
+        return shouldChangeCharacters.call((textField.value, range, string)) ?? true
+    }
+
+    public func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        return shouldClear.call(textField.value) ?? true
+    }
+
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        return shouldReturn.call(textField.value) ?? true
+    }
+
+    /// Return true whether the proposed updated text should be accepted or not.
+    /// - Note: Is based on `shouldChangeCharacters` so only one of the two can be used at a time.
+    public lazy var shouldChangeToProposedText = Delegate<String, Bool> { [weak self] isValidNewString in
+        guard let `self` = self else { return NilDisposer() }
+
+        return self.shouldChangeCharacters.set { text, range, replacementString in
+            let proposedText = text.replacingCharacters(in: range, with: replacementString)
+            return isValidNewString(proposedText)
+        }
+    }
+}
+
+public extension TextFieldDelegate {
+    var didEndEditing: Signal<()> {
+        return Signal(callbacker: didEndEditingCallbacker)
+    }
+}
+
+public extension UITextField {
+    func install(_ delegate: UITextFieldDelegate) -> Disposable {
+        self.delegate = delegate
+        return Disposer {
+            _ = delegate // Hold on to
+            self.delegate = nil
+        }
+    }
+}

--- a/Form/TextFieldDelegate.swift
+++ b/Form/TextFieldDelegate.swift
@@ -42,22 +42,22 @@ public final class TextFieldDelegate: NSObject, UITextFieldDelegate {
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         return shouldReturn.call(textField.value) ?? true
     }
-
-    /// Return true whether the proposed updated text should be accepted or not.
-    /// - Note: Is based on `shouldChangeCharacters` so only one of the two can be used at a time.
-    public lazy var shouldChangeToProposedText = Delegate<String, Bool> { [weak self] isValidNewString in
-        guard let `self` = self else { return NilDisposer() }
-
-        return self.shouldChangeCharacters.set { text, range, replacementString in
-            let proposedText = text.replacingCharacters(in: range, with: replacementString)
-            return isValidNewString(proposedText)
-        }
-    }
 }
 
 public extension TextFieldDelegate {
     var didEndEditing: Signal<()> {
         return Signal(callbacker: didEndEditingCallbacker)
+    }
+
+    /// Return true whether the proposed updated text should be accepted or not.
+    /// - Note: Is based on `shouldChangeCharacters` so only one of the two can be used at a time.
+    public var shouldChangeToProposedText: Delegate<String, Bool> {
+        return Delegate { isValidNewString in
+            self.shouldChangeCharacters.set { text, range, replacementString in
+                let proposedText = text.replacingCharacters(in: range, with: replacementString)
+                return isValidNewString(proposedText)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- Added `TextFieldDelegate` similar to `ScrollViewDelegate` and friends.
- Added `UITextField` and `UIScrollView` `install()` delegate helpers.

Discussion: Flow currently have some support for textfield delegate as an extension on textfield:

```swift
public extension UITextField {
    /// Delegate for asking if editing should stop in the specified text field
    /// - See: UITextFieldDelegate.textFieldShouldEndEditing()
    /// - Note: Any currently set delegate will be overridden, unless the delegate was set by `shouldEndEditing` or `shouldReturn`.
    var shouldEndEditing: Delegate<String, Bool> {
        return Delegate { callback in self.usingDelegate { $0.shouldEndEditing.set(callback) } }
    }

    /// Delegate for asking whether the text field should process the pressing of the return button
    /// - See: UITextFieldDelegate.textFieldShouldReturn()
    /// - Note: Any currently set delegate will be overridden, unless the delegate was set by `shouldEndEditing` or `shouldReturn`.
    var shouldReturn: Delegate<String, Bool> {
        return Delegate { callback in self.usingDelegate { $0.shouldReturn.set(callback) } }
    }
}
```

I suggest we should deprecate the two helpers above and refer to the new Form `TextFieldDelegate` instead as this is more in line how we typically work with delegates lately. I considered adding this to Flow instead, but that also feels strange as our other delegates were added to Form. 

An alternative is to move our delegates up to Flow as they are general and not really related to Form?
