### PR TITLE
Make the resizable area bigger than 1px to avoid border artefacts resized

### DIFF
--- a/Form/UIImage+Styling.swift
+++ b/Form/UIImage+Styling.swift
@@ -64,8 +64,8 @@ extension UIImage {
         let ceiledTopSeparatorHeight = ceil(topSeparatorHeight)
 
         // Computing the smallest rect possible to draw this image - note that it should be slightly bigger than the border widths so that it draws a stretchable non-solid area too
-        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + .thinestLineWidth + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
-        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + .thinestLineWidth + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
+        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + 2 * .thinestLineWidth + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
+        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + 2 * .thinestLineWidth + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
         let rect = CGRect(x: 0, y: 0, width: max(1, rectWidth), height: max(1, rectHeight))
 
         let isOpaque: Bool


### PR DESCRIPTION
I'm struggling with this one. Basically in `UIImage+Styling` we are generating images from color and border style. There were couple of bugs addressed in 1.3.3 and now all seems to work properly. I did several snapshot tests with different border styles and sizes and they look good. But now I'm experiencing problems when using an image generated with this method in segmented controls. 

I modified the Demo project on a [separate branch](segmented-control-underline-bug-example) to illustrate the glitch (when switching segments the border expands its height):
https://github.com/iZettle/Form/commit/411a2e0c1b894b831da06a224d53f783cbc45b23
![selection-glitch](https://user-images.githubusercontent.com/1555713/47279553-2b3bfc00-d5d2-11e8-8534-0e41273e0a5f.gif)

From the [UISegmentedControl docs:](https://developer.apple.com/documentation/uikit/uisegmentedcontrol/1618571-setbackgroundimage?language=objc):
```
If backgroundImage is an image returned from resizableImageWithCapInsets:, the cap widths are calculated from that information.
```

We seem to be calculating the smallest image and its cap insets properly.

This is the pattern image used for it (it's very small, you can open it separately):
![pattern_image](https://user-images.githubusercontent.com/1555713/47279560-3bec7200-d5d2-11e8-8292-fd1c3a6edb09.png)

It is `(h: 3.33, w: 1)` on 3x with the red part being `(h: 3, w: 1)`. The cap insets are `(top: 0, left: 0, bottom: 3, right: 0)`.

For some reason this is not enough. I checked and it doesn't seem to be a rounding problem. The smallest additional resizable value that fixes the problem without visible side-effects (at least from my testing) is 1 more resizable pixel. So that's why `2 * .thinestLineWidth` which is `0.66` on 3x. 

I don't have a better idea or explanation at the moment. Any advices are welcome.
