### PR TITLE
Fix table footer height on iOS 9

### DIFF
--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -110,15 +110,9 @@ public final class TableKit<Section, Row> {
 
         let tableHeader = UIView()
         let tableHeaderConstraint = activate(tableHeader.heightAnchor == 0)
-        if view.tableHeaderView == nil {
-            view.autoResizingTableHeaderView = tableHeader
-        }
 
         let tableFooter = UIView()
         let tableFooterConstraint = activate(tableFooter.heightAnchor == 0)
-        if view.tableFooterView == nil {
-            view.autoResizingTableFooterView = tableFooter
-        }
 
         bag += view.traitCollectionWithFallbackSignal.distinct().atOnce().onValue { traits in
             let style = style.style(from: traits)
@@ -149,6 +143,14 @@ public final class TableKit<Section, Row> {
             if self.delegate.footerHeight == 0 { // 0 has special meaning, not what we want
                 self.delegate.footerHeight = .headerFooterAlmostZero
             }
+        }
+
+        if view.tableHeaderView == nil {
+            view.autoResizingTableHeaderView = tableHeader
+        }
+
+        if view.tableFooterView == nil {
+            view.autoResizingTableFooterView = tableFooter
         }
 
         bag += dataSource.cellForIndex.set { index in


### PR DESCRIPTION
Fixing a string bug on iOS 9.

On iOS 9 the delegate `tableView(_ tableView:, heightForFooterInSection:)` is called right after the `tableFooterView` is set and called later on on other iOS versions.
So I just moved the `view.autoResizingTableFooterView = tableFooter` after the style is set in TableKit to fix this issue on iOS 9...