### PR TITLE
Revert "Fix table footer height on iOS 9"

### DIFF
--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -110,9 +110,15 @@ public final class TableKit<Section, Row> {
 
         let tableHeader = UIView()
         let tableHeaderConstraint = activate(tableHeader.heightAnchor == 0)
+        if view.tableHeaderView == nil {
+            view.autoResizingTableHeaderView = tableHeader
+        }
 
         let tableFooter = UIView()
         let tableFooterConstraint = activate(tableFooter.heightAnchor == 0)
+        if view.tableFooterView == nil {
+            view.autoResizingTableFooterView = tableFooter
+        }
 
         bag += view.traitCollectionWithFallbackSignal.distinct().atOnce().onValue { traits in
             let style = style.style(from: traits)
@@ -143,14 +149,6 @@ public final class TableKit<Section, Row> {
             if self.delegate.footerHeight == 0 { // 0 has special meaning, not what we want
                 self.delegate.footerHeight = .headerFooterAlmostZero
             }
-        }
-
-        if view.tableHeaderView == nil {
-            view.autoResizingTableHeaderView = tableHeader
-        }
-
-        if view.tableFooterView == nil {
-            view.autoResizingTableFooterView = tableFooter
         }
 
         bag += dataSource.cellForIndex.set { index in


### PR DESCRIPTION
Reverts iZettle/Form#60

This is currently causing other issues because the `estimatedSectionHeaderHeight`/`estimatedSectionFooterHeight` are not set properly because the header and footer are set after the block using them.

Reverting and if there are still issues on iOS 9 we should try to find a fix that works on all versions and cover it with some tests.