### PR TITLE
Replace force unwrap of associated value to guard and early return

### DIFF
--- a/Form/UITableViewCell+Utilities.swift
+++ b/Form/UITableViewCell+Utilities.swift
@@ -113,7 +113,10 @@ public extension UITableView {
 
 public extension UITableViewCell {
     func applyFormStyle(_ style: TableViewFormStyle) {
-        let (embeddedView, heightConstraint, _, updateInsets) = (associatedValue(forKey: &tableFormKey) as (UIView, NSLayoutConstraint, DisposeBag, (UIEdgeInsets) -> ())?)!
+
+        guard let (embeddedView, heightConstraint, _, updateInsets) = (associatedValue(forKey: &tableFormKey) as (UIView, NSLayoutConstraint, DisposeBag, (UIEdgeInsets) -> ())?) else {
+            return
+        }
 
         heightConstraint.constant = style.section.minRowHeight
 


### PR DESCRIPTION
### What

While applying form style to `UITableViewCell`, we force unwrap the associated variable. But because the method is in the extension over `UITableViewCell` there can be a case that UITableViewCell was created with a different initialiser that never has this associated variable. And thus leading to crash.

We fix it by implementing an early return which might end up with visual bugs but no crashes.

- [ ] Write a test to reproduce a crash.