### PR TITLE
Add compound assignment for stack views

### DIFF
--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		7270AFB0201FAB7C004DAAA3 /* ViewLayoutArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */; };
 		B35F8AEE1F36676D00904E37 /* Collection+Changes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F8AED1F36676D00904E37 /* Collection+Changes.swift */; };
 		B35F8B4C1F3783E400904E37 /* CollectionDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */; };
+		C3C760A821B968640081F416 /* UtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C760A721B968640081F416 /* UtilitiesTests.swift */; };
 		CA6755EA1D4B6F1C000662FF /* SegmentedControlStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6755E91D4B6F1C000662FF /* SegmentedControlStyle.swift */; };
 		CD49499B1C199520000176D3 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		CDD2A5211F42DE7500E2B78B /* HighlightedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD2A5201F42DE7500E2B78B /* HighlightedTests.swift */; };
@@ -137,6 +138,7 @@
 		7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewLayoutArea.swift; path = Form/ViewLayoutArea.swift; sourceTree = "<group>"; };
 		B35F8AED1F36676D00904E37 /* Collection+Changes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Collection+Changes.swift"; path = "Form/Collection+Changes.swift"; sourceTree = "<group>"; };
 		B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionDiffTests.swift; sourceTree = "<group>"; };
+		C3C760A721B968640081F416 /* UtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTests.swift; sourceTree = "<group>"; };
 		CA6755E91D4B6F1C000662FF /* SegmentedControlStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SegmentedControlStyle.swift; path = Form/SegmentedControlStyle.swift; sourceTree = "<group>"; };
 		CDD2A5201F42DE7500E2B78B /* HighlightedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HighlightedTests.swift; sourceTree = "<group>"; };
 		E63D89BE1DF59D6100AAB381 /* DisplayableString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DisplayableString.swift; path = Form/DisplayableString.swift; sourceTree = SOURCE_ROOT; };
@@ -270,6 +272,7 @@
 				B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */,
 				F604260920B6A47E00BC4CAB /* ParentChildRelationalTests.swift */,
 				F6B81B9320CA906000B6AC39 /* NumberEditorTests.swift */,
+				C3C760A721B968640081F416 /* UtilitiesTests.swift */,
 				F62E45B81CABFB5300C6867E /* Info.plist */,
 			);
 			path = FormTests;
@@ -578,6 +581,7 @@
 				B35F8B4C1F3783E400904E37 /* CollectionDiffTests.swift in Sources */,
 				21367C6B1DACDF990021C98F /* TableChangeTests.swift in Sources */,
 				1C2881831F20EE2000666A21 /* SelectViewTests.swift in Sources */,
+				C3C760A821B968640081F416 /* UtilitiesTests.swift in Sources */,
 				1CDD56AA1D9C10D7004B0CA9 /* TableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Form/UIStackView+Layout.swift
+++ b/Form/UIStackView+Layout.swift
@@ -74,6 +74,16 @@ public extension UIStackView {
     }
 }
 
+public extension UIStackView {
+    public static func += (left: inout UIStackView, right: UIView) {
+        left.addArrangedSubview(right)
+    }
+
+    public static func += (left: inout UIStackView, right: [UIView]) {
+        right.forEach { view in left.addArrangedSubview(view) }
+    }
+}
+
 extension UIStackView: SubviewOrderable {
     public var orderedViews: [UIView] {
         get { return arrangedSubviews }

--- a/FormTests/UtilitiesTests.swift
+++ b/FormTests/UtilitiesTests.swift
@@ -1,0 +1,59 @@
+//
+//  UtilitiesTests.swift
+//  FormTests
+//
+//  Created by Carl Ekman on 2018-12-06.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import XCTest
+import Form
+
+class StackViewTests: XCTestCase {
+
+    func testHelperFunction() {
+        let empty = UIStackView(arrangedSubviews: [])
+        let single = UIStackView(arrangedSubviews: [UIView(tag: 0)])
+        let stack = UIStackView(arrangedSubviews: [UIView(tag: 0), UIView(tag: 1), UIView(tag: 2)])
+        let wrong = UIStackView(arrangedSubviews: [UIView(tag: 0), UIView(tag: 2), UIView(tag: 1)])
+
+        XCTAssertFalse(empty.subviewsHaveTagsEqualToIndex)
+        XCTAssertTrue(single.subviewsHaveTagsEqualToIndex)
+        XCTAssertTrue(stack.subviewsHaveTagsEqualToIndex)
+        XCTAssertFalse(wrong.subviewsHaveTagsEqualToIndex)
+    }
+
+    func testCompoundAssignments() {
+        var stack = UIStackView(arrangedSubviews: [UIView(tag: 0), UIView(tag: 1), UIView(tag: 2)])
+        stack += [UIView(tag: 3), UIView(tag: 4)]
+        stack += UIView(tag: 5)
+
+        XCTAssertTrue(stack.subviewsHaveTagsEqualToIndex)
+    }
+
+    func testCompoundAssignmentsFromEmpty() {
+        var stack = UIStackView(arrangedSubviews: [])
+        stack += UIView(tag: 0)
+        stack += [UIView(tag: 1), UIView(tag: 2)]
+        stack += UIView(tag: 3)
+
+        XCTAssertTrue(stack.subviewsHaveTagsEqualToIndex)
+    }
+}
+
+fileprivate extension UIStackView {
+    var subviewsHaveTagsEqualToIndex: Bool {
+        guard arrangedSubviews.count > 0 else { return false }
+
+        return arrangedSubviews.enumerated().reduce(true) { (last, this) in
+            let (index, view) = this
+            return last && (view.tag == index) }
+    }
+}
+
+fileprivate extension UIView {
+    convenience init(tag: Int) {
+        self.init(frame: .zero)
+        self.tag = tag
+    }
+}


### PR DESCRIPTION
### What
This is something I was missing from `UIStackView` when working, that I thought already was a part of `Form`. I think it makes for a convenient little addition to the framework. What do you think? Maybe placing this outside of Form is better?

### Example use case
```Swift
var stack = UIStackView(rows: [myImageView, myTitleLabel, myMessageLabel])
if let action = optionalAction {
    let myButton = UIButton(withAction: action)
    stack += [UIView(height: .spacing), myButton]
}
```