### PR TITLE
Reset the transform applied on reorder control before changing its frame

### DIFF
--- a/Form/UITableViewCell+Utilities.swift
+++ b/Form/UITableViewCell+Utilities.swift
@@ -120,6 +120,7 @@ public extension UITableViewCell {
         let reorderViewTag = 473659834
         if let reorderControlView = reorderControlView {
             let resizedGripView = viewWithTag(reorderViewTag) ?? TapThroughView()
+            resizedGripView.transform = .identity
             resizedGripView.frame = bounds
             resizedGripView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             resizedGripView.backgroundColor = .clear


### PR DESCRIPTION
This PR addressed a bug where the reorder control will have wrong position in a cell like this:
![reorder_control](https://user-images.githubusercontent.com/1555713/51477366-8c699c00-1d88-11e9-9aa1-f23aa62ff4bc.png)

We apply the following transform to the reorder control:
`resizedGripView.transform = CGAffineTransform(translationX: -style.form.insets.right, y: 0)`

For a style with insets (h: 20, v:0) our reorder control will get x position -20 after applying this transform. If a style is applied again to the same cell its frame is reset with zero origin but the transform remains to at the end the x position id 0 instead of -20.

This PR doesn't address the way the reorder control is currently added to cells which might also need some attention.

Note: This is one more case in which we are missing a snapshot test in this repository covering the fix. I will open an issue to document that we want to add snapshot tests here in the future and move some of the tests we have internally.