### PR TITLE
Activate constraints before calls to layoutIfNeeded to prevent crashes on iOS 9/10

### DIFF
--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -149,7 +149,8 @@ private extension UIScrollView {
 
         // Handle transitions views that are not custom (our zoom modal). How fragile is this logic?
         if let coord = viewController?.transitionCoordinator, coord.presentationStyle != .custom,
-            let containerView: UIView = (coord as? NSObject)?.value(forKey: "containerView") as? UIView { // Using value(forKey:) as non-optional coord.containerView might return nil on iOS 9
+            let containerView: UIView = (coord as? NSObject)?.value(forKey: "containerView") as? UIView,
+            self.isDescendant(of: containerView) { // Using value(forKey:) as non-optional coord.containerView might return nil on iOS 9
             parent = containerView
         } else if let superview = self.superview {
             parent = superview
@@ -235,7 +236,7 @@ private extension UIScrollView {
         // The parent moved between views when being presented and dismissed etc.
         // This mean we have to re-pin if that happens.
         // FIXME: In iOS 11 we should be able to use contentLayoutGuide instead of parent to setup our constraints and be able to remove this hack.
-        bag += combineLatest(parent.subviewsSignal.plain(), didMoveToWindowSignal).onValue { _ in
+        bag += combineLatest(parent.subviewsSignal.plain(), windowSignal.plain()).onValue { [weak parent] _ in
             guard let superView = self.superview, superView != parent else { return }
 
             let offset = self.contentOffset.y

--- a/Form/UIScrollView+Spacing.swift
+++ b/Form/UIScrollView+Spacing.swift
@@ -52,6 +52,10 @@ public extension UIScrollView {
             bottom.constant = $0
         }
 
+        // The added constraints need to be activated before any calls to `layoutIfNeeded` because the layout might be unsatisfiable otherwise
+        activate(constraints)
+        disembedBag += { deactivate(constraints) }
+
         // .equalSpacing gives ambigious layout on iOS < 11, help out by calculating spacing manually.
         if #available(iOS 11, *) {} else if orderedViews.count > 0 {
             let contentHeight = signal(for: \.contentSize)[\.height].toVoid().atValue {
@@ -72,9 +76,6 @@ public extension UIScrollView {
                     self.layoutIfNeeded()
             }
         }
-
-        activate(constraints)
-        disembedBag += { deactivate(constraints) }
 
         return bag
     }


### PR DESCRIPTION
We are experiencing crashes on iOS 9/10 caused by [this](https://github.com/iZettle/Form/compare/release-patch-1.5.1?expand=1#diff-a1cc0eb44a1d6536ed09eb9cd4de3b12R76) `layoutIfNeeded` call. The call is triggered by a signal subscription with `atOnce` which means that it is executed right away, before constraints are activated. This leads to a crash with the following stack which suggests unsatisfiable layout.
<img width="509" alt="screen shot 2019-01-29 at 12 00 47" src="https://user-images.githubusercontent.com/1555713/51904140-2ef3d180-23be-11e9-90a3-109223753de7.png">
We were able to reproduce the crash 100% and with this fix it is no longer reproducible however this is not sufficient long term solution since the bug can be easily re-introduced. 

TODO:
We're gonna work on adding a test that reproduces it and consider running tests on iOS 10 device as well on the CI. We're gonna try to do it as part of this PR but if the scope grows too much will do it separately. 