### PR TITLE
Fix a bug where a view is pinned to UITransitionView that is no longer shown

### DIFF
--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -149,7 +149,8 @@ private extension UIScrollView {
 
         // Handle transitions views that are not custom (our zoom modal). How fragile is this logic?
         if let coord = viewController?.transitionCoordinator, coord.presentationStyle != .custom,
-            let containerView: UIView = (coord as? NSObject)?.value(forKey: "containerView") as? UIView { // Using value(forKey:) as non-optional coord.containerView might return nil on iOS 9
+            let containerView: UIView = (coord as? NSObject)?.value(forKey: "containerView") as? UIView,
+            self.isDescendant(of: containerView) { // Using value(forKey:) as non-optional coord.containerView might return nil on iOS 9
             parent = containerView
         } else if let superview = self.superview {
             parent = superview
@@ -235,7 +236,7 @@ private extension UIScrollView {
         // The parent moved between views when being presented and dismissed etc.
         // This mean we have to re-pin if that happens.
         // FIXME: In iOS 11 we should be able to use contentLayoutGuide instead of parent to setup our constraints and be able to remove this hack.
-        bag += combineLatest(parent.subviewsSignal.plain(), didMoveToWindowSignal).onValue { _ in
+        bag += combineLatest(parent.subviewsSignal.plain(), windowSignal.plain()).onValue { [weak parent] _ in
             guard let superView = self.superview, superView != parent else { return }
 
             let offset = self.contentOffset.y

--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -236,7 +236,7 @@ private extension UIScrollView {
         // The parent moved between views when being presented and dismissed etc.
         // This mean we have to re-pin if that happens.
         // FIXME: In iOS 11 we should be able to use contentLayoutGuide instead of parent to setup our constraints and be able to remove this hack.
-        bag += combineLatest(parent.subviewsSignal.plain(), windowSignal.plain()).onValue { [weak parent] _ in
+        bag += combineLatest(parent.subviewsSignal, windowSignal).onValue { [weak parent] _ in
             guard let superView = self.superview, superView != parent else { return }
 
             let offset = self.contentOffset.y


### PR DESCRIPTION
Since we are listening to the `didMoveToWindowSignal` we don't get notified when the view we're pinning to is removed from its window. Using the `windowSignal` fixes that problem but a transition view might still not be deallocated after it was removed from the window in which case we would try to pin our view to it but we will get a crash because the views are not in the same hierarchy (that's why the `isDescendant(of:)` check is needed). Additionally, we were keeping a strong reference in a block to the transition view which prevented if from being deallocated which is resolved with the added `[weak parent]`.