### PR TITLE
Fix swiftlint and build warnings

### DIFF
--- a/Form/ButtonStateStyle.swift
+++ b/Form/ButtonStateStyle.swift
@@ -41,8 +41,8 @@ extension UIControlState: Equatable {
 }
 
 extension UIControlState: Hashable {
-    public var hashValue: Int {
-        return Int(rawValue)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
 }
 

--- a/Form/CollectionKit.swift
+++ b/Form/CollectionKit.swift
@@ -28,10 +28,10 @@ public final class CollectionKit<Section, Row> {
     public var table: Table {
         get { return dataSource.table }
         set {
-            dataSource.table = table
-            delegate.table = table
+            dataSource.table = newValue
+            delegate.table = newValue
             view.reloadData()
-            callbacker.callAll(with: table)
+            callbacker.callAll(with: newValue)
         }
     }
 

--- a/Form/Table.swift
+++ b/Form/Table.swift
@@ -245,8 +245,9 @@ extension TableIndex: Comparable {
         return lhs.section == rhs.section ? lhs.row < rhs.row : lhs.section < rhs.section
     }
 
-    public var hashValue: Int {
-        return section.hashValue &+ row.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(section)
+        hasher.combine(row)
     }
 }
 

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -29,10 +29,10 @@ public final class TableKit<Section, Row> {
     public var table: Table {
         get { return dataSource.table }
         set {
-            dataSource.table = table
-            delegate.table = table
+            dataSource.table = newValue
+            delegate.table = newValue
             view.reloadData()
-            callbacker.callAll(with: table)
+            callbacker.callAll(with: newValue)
         }
     }
 

--- a/Form/TextEditor.swift
+++ b/Form/TextEditor.swift
@@ -63,6 +63,7 @@ public func isDigit(_ character: Character) -> Bool {
 public class AnyTextEditor<Value>: TextEditor {
     public var value: Value {
         get { fatalError() }
+        // swiftlint:disable:next unused_setter_value
         set { fatalError() }
     }
 

--- a/Form/ValueField.swift
+++ b/Form/ValueField.swift
@@ -157,6 +157,7 @@ public final class ValueField<Value>: UIControl, UIKeyInput {
     /// Always use `.no` autocorrection as the system keyboard will be confused if it is used.
     public dynamic var autocorrectionType: UITextAutocorrectionType {
         get { return .no }
+        //swiftlint:disable:next unused_setter_value
         set { /* ignore */ }
     }
 


### PR DESCRIPTION
There were some linter warnings that were disabled and implement `func hash(into:)` in favor of `var hashValue`