### PR TITLE
Add minimumScalingFactor to ButtonStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.7
+- Add optional minimum scaling factor for UIButton titleLabel to ButtonStyle
+
 ## 1.6.1
 - Bugfix: Fix layout problem caused by pinning a view to UITransitionView that is no longer shown on iOS 9/10
 - Bugfix: Activate constraints before calls to layoutIfNeeded to prevent crashes on iOS 9/10 when embedding views in a scrollView

--- a/Form/ButtonStyle.swift
+++ b/Form/ButtonStyle.swift
@@ -13,20 +13,22 @@ public struct ButtonStyle: Style {
     public var contentInsets: UIEdgeInsets
     public var preferredMinimumSize: MinimumSize
     public var alignment: UIControlContentHorizontalAlignment
+    public var minimumScalingFactor: CGFloat
     public var states: [UIControlState: ButtonStateStyle]
 
-    public init(buttonType: UIButtonType = .custom, contentInsets: UIEdgeInsets = .zero, preferredMinimumSize: MinimumSize = .none, alignment: UIControlContentHorizontalAlignment = .center, states: [UIControlState: ButtonStateStyle]) {
+    public init(buttonType: UIButtonType = .custom, contentInsets: UIEdgeInsets = .zero, preferredMinimumSize: MinimumSize = .none, minimumScalingFactor: CGFloat = 1.0, alignment: UIControlContentHorizontalAlignment = .center, states: [UIControlState: ButtonStateStyle]) {
         self.buttonType = buttonType
         self.contentInsets = contentInsets
         self.preferredMinimumSize = preferredMinimumSize
+        self.minimumScalingFactor = minimumScalingFactor
         self.alignment =  alignment
         self.states = states
     }
 }
 
 public extension ButtonStyle {
-    init(buttonType: UIButtonType = .custom, contentInsets: UIEdgeInsets = .zero, preferredMinimumSize: MinimumSize = .none, alignment: UIControlContentHorizontalAlignment = .center, normal: ButtonStateStyle? = nil, highlighted: ButtonStateStyle? = nil, disabled: ButtonStateStyle? = nil, selected: ButtonStateStyle? = nil) {
-        self.init(buttonType: buttonType, contentInsets: contentInsets, preferredMinimumSize: preferredMinimumSize, alignment: alignment, states: .init(normal: normal, highlighted: highlighted, disabled: disabled, selected: selected))
+    init(buttonType: UIButtonType = .custom, contentInsets: UIEdgeInsets = .zero, preferredMinimumSize: MinimumSize = .none, minimumScalingFactor: CGFloat = 1.0, alignment: UIControlContentHorizontalAlignment = .center, normal: ButtonStateStyle? = nil, highlighted: ButtonStateStyle? = nil, disabled: ButtonStateStyle? = nil, selected: ButtonStateStyle? = nil) {
+        self.init(buttonType: buttonType, contentInsets: contentInsets, preferredMinimumSize: preferredMinimumSize, minimumScalingFactor: minimumScalingFactor, alignment: alignment, states: .init(normal: normal, highlighted: highlighted, disabled: disabled, selected: selected))
     }
 }
 
@@ -123,6 +125,7 @@ private extension UIButton {
         self.contentEdgeInsets = style.contentInsets
         self.contentHorizontalAlignment = style.alignment
         updateMinimumSize(style.preferredMinimumSize)
+        titleLabel?.minimumScaleFactor = style.minimumScalingFactor
 
         for state in UIControlState.standardStates {
             let stateStyle = style.states[state]

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<string>1.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<string>1.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### What has been done?

This PR adds a property `minimumScalingFactor` to `ButtonStyle` which is applied to `UIButton`'s titleLabel. This allows us to create styles for Buttons and specify if we want to scaled down the font size if the text does not fit the button size. Currently we do it in project after creating a button with a style. But to make the scaling consistent and remove the redundancy of setting it up, it made more sense to have it as a property in `ButtonStyle`