### PR TITLE
Bump to 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.6.2
-- Bugfix: Setting `table` direclty on `TableKit` or `CollectionKit` did not reload the view correctly with the updated table.
+- Bugfix: Setting `table` direclty on `TableKit` or `CollectionKit` did not reload the view correctly with the provided table.
 
 ## 1.6.1
 - Bugfix: Fix layout problem caused by pinning a view to UITransitionView that is no longer shown on iOS 9/10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.2
+- Bugfix: Setting `table` direclty on `TableKit` or `CollectionKit` did not reload the view correctly with the updated table.
+
 ## 1.6.1
 - Bugfix: Fix layout problem caused by pinning a view to UITransitionView that is no longer shown on iOS 9/10
 - Bugfix: Activate constraints before calls to layoutIfNeeded to prevent crashes on iOS 9/10 when embedding views in a scrollView

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.6.2
-- Bugfix: Setting `table` direclty on `TableKit` or `CollectionKit` did not reload the view correctly with the provided table.
+- Bugfix: Setting `table` direclty on `TableKit` or `CollectionKit` did not reload the view correctly with the updated table.
 
 ## 1.6.1
 - Bugfix: Fix layout problem caused by pinning a view to UITransitionView that is no longer shown on iOS 9/10

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<string>1.6.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.6.1"
+  s.version      = "1.6.2"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC


### PR DESCRIPTION
To release fixes from [7c5a45f](https://github.com/iZettle/Form/commit/7c5a45f3ea3fd2d4957b3670fd19fb6a5ed96c4b)