### PR TITLE
Add letter spacing and line height to TextStyle

### DIFF
--- a/Documentation/Styling.md
+++ b/Documentation/Styling.md
@@ -111,14 +111,14 @@ let image = UIImage(image: background)
 `TextStyle` supports the same styling as attributed strings. Not all attributes are exposed as convenience properties though. You can still set these using:
 
 ```swift
-textStyle.setAttribute(kerning, for: .kern)
+textStyle.setAttribute(letterSpacing, for: .kern)
 ```
 
 But preferably you should add helpers instead:
 
 ```swift
 extension TextStyle {
-  var kerning: Float {
+  var letterSpacing: Float {
     get { return attribute(for: .kern) ?? 0 }
     set { setAttribute(newValue, for: .kern, defaultValue: 0) }
   } 

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -56,8 +56,9 @@ public extension TextStyle {
         set { setParagraphAttribute(newValue, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } }
     }
 
-    /// The amount of space between baselines in a block of text. It is affected by `font` and `lineSpacing` updates.
+    /// The amount of space between baselines in a block of text.
     /// - Note: The line height can't be set smaller than the font size to prevent overlap of characters.
+    /// - Note: The line height can be affected by `font` and `lineSpacing` updates.
     var lineHeight: CGFloat {
         get { return (attribute(for: .lineSpacing) ?? 0) + font.lineHeight }
         set { setParagraphAttribute(max(newValue, font.pointSize) - font.lineHeight, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } }

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -56,7 +56,6 @@ public extension TextStyle {
         set { setParagraphAttribute(newValue, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } }
     }
 
-    var kerning: Float {
     /// The amount of space between baselines in a block of text. It is affected by `font` and `lineSpacing` updates.
     /// - Note: The line height can't be set smaller than the font size to prevent overlap of characters.
     var lineHeight: CGFloat {
@@ -64,8 +63,16 @@ public extension TextStyle {
         set { setParagraphAttribute(max(newValue, font.pointSize) - font.lineHeight, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } }
     }
 
+    /// The uniform adjustment of the space between letters in text. Also referred to as tracking.
+    var letterSpacing: Float {
         get { return attribute(for: .kern) ?? 0 }
         set { setAttribute(newValue, for: .kern, defaultValue: 0) }
+    }
+
+    @available(*, deprecated, renamed: "letterSpacing")
+    var kerning: Float {
+        get { return letterSpacing }
+        set { letterSpacing = newValue }
     }
 
     var numberOfLines: Int {

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -50,12 +50,20 @@ public extension TextStyle {
         set { setParagraphAttribute(newValue, for: .lineBreakMode, defaultValue: .byTruncatingTail) { $0.lineBreakMode = newValue } }
     }
 
+    /// The amount of space between text's bounding boxes.
     var lineSpacing: CGFloat {
         get { return attribute(for: .lineSpacing) ?? 0 }
         set { setParagraphAttribute(newValue, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } }
     }
 
     var kerning: Float {
+    /// The amount of space between baselines in a block of text. It is affected by `font` and `lineSpacing` updates.
+    /// - Note: The line height can't be set smaller than the font size to prevent overlap of characters.
+    var lineHeight: CGFloat {
+        get { return (attribute(for: .lineSpacing) ?? 0) + font.lineHeight }
+        set { setParagraphAttribute(max(newValue, font.pointSize) - font.lineHeight, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } }
+    }
+
         get { return attribute(for: .kern) ?? 0 }
         set { setAttribute(newValue, for: .kern, defaultValue: 0) }
     }

--- a/FormTests/TextStyleTests.swift
+++ b/FormTests/TextStyleTests.swift
@@ -23,4 +23,38 @@ class TextStyleTests: XCTestCase {
         XCTAssertNotEqual(textStyle1, textStyle4)
         XCTAssertNotEqual(textStyle1, textStyle5)
     }
+
+    func testCustomLineHeightIsSet_biggerThanFontLineHeight() {
+        let font = UIFont.systemFont(ofSize: 14.0)
+        let textStyle = TextStyle(font: font, color: .red).restyled { $0.lineHeight = 30.0 }
+        XCTAssertEqual(textStyle.lineHeight, 30.0)
+    }
+
+    func testCustomLineHeightIsSet_smallerThanFontLineHeight_biggerThanFontSize() {
+        let font = UIFont.systemFont(ofSize: 14.0)
+        let textStyle = TextStyle(font: font, color: .red).restyled { $0.lineHeight = 15.0 }
+        XCTAssertEqual(textStyle.lineHeight, 15.0)
+    }
+
+    func testCustomLineHeightIsCorrectedToFontSize_smallerThanFontSize() {
+        let font = UIFont.systemFont(ofSize: 14.0)
+        let textStyle = TextStyle(font: font, color: .red).restyled { $0.lineHeight = 13.0 }
+        XCTAssertEqual(textStyle.lineHeight, 14.0)
+    }
+
+    func testIncreasingLineSpacingIncreasesLineHeight() {
+        let font = UIFont.systemFont(ofSize: 14.0)
+        var textStyle = TextStyle(font: font, color: .red)
+        let initialLineHeight = textStyle.lineHeight
+        textStyle.lineSpacing = 2.0
+        XCTAssertTrue(textStyle.lineHeight > initialLineHeight)
+    }
+
+    func testIncreasingLineHeightIncreasesLineSpacing() {
+        let font = UIFont.systemFont(ofSize: 14.0)
+        var textStyle = TextStyle(font: font, color: .red)
+        let initialLineSpacing = textStyle.lineSpacing
+        textStyle.lineHeight += 2.0
+        XCTAssertTrue(textStyle.lineSpacing > initialLineSpacing)
+    }
 }


### PR DESCRIPTION
There are two changes to TextStyle in this PR:

1. Added a `lineHeight` property to allow us to conveniently specify the spacing between baselines of text. Designers often use this term instead of `lineSpacing`. Even though it is possible to achieve the same resulting line height through the `lineSpacing` paragraph attribute it is not very convenient to make that calculation all the time.
2. Renamed the `kerning` property because it is not really accurate name for the way we use it. From wikipedia: `Kerning adjusts the space between individual letter forms, while tracking (letter-spacing) adjusts spacing uniformly over a range of characters`. Currently when this attribute is set we adjust the spacing between all letters in the text so  tracking or letter-spacing are more accurate names. Given that `tracking` might not be descriptive enough to non-designers I used `letterSpacing`. The `kerning` property is now deprecated and just uses `letterSpacing` behind the scenes.