### PR TITLE
Styling/text/fix line height

### DIFF
--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -65,7 +65,7 @@ public extension TextStyle {
     }
 
     /// The amount of space between baselines in a block of text.
-    /// - Note: The line height can't be set smaller than the font size to prevent overlap of characters.
+    /// - Note: The line height can't be set smaller than the font size. Beaware that setting smaller line height than the font line height may result in overlapping characters.
     /// - Note: The line height can be affected by `font` and `lineSpacing` updates.
     var lineHeight: CGFloat {
         get { return (attribute(for: .lineSpacing) ?? 0) + font.lineHeight }

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -69,7 +69,7 @@ public extension TextStyle {
     /// - Note: The line height can be affected by `font` and `lineSpacing` updates.
     var lineHeight: CGFloat {
         get { return (attribute(for: .lineSpacing) ?? 0) + font.lineHeight }
-        set { setParagraphAttribute(max(newValue, font.pointSize) - font.lineHeight, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } }
+        set { lineSpacing = max(newValue, font.pointSize) - font.lineHeight }
     }
 
     /// The uniform adjustment of the space between letters in text. Also referred to as tracking.

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -53,7 +53,15 @@ public extension TextStyle {
     /// The amount of space between text's bounding boxes.
     var lineSpacing: CGFloat {
         get { return attribute(for: .lineSpacing) ?? 0 }
-        set { setParagraphAttribute(newValue, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } }
+        set {
+            /// We are currently not restricting line spacing to nonnegative values.
+            /// Even though the docs say "This value is always nonnegative", it can be negative and there are fonts that can benefit such corection.
+            /// However, the text position is not calculated properly with negative line spacing unless the `baselineOffset` is set.
+            if attribute(for: .baselineOffset) == nil {
+                setAttribute(0, for: .baselineOffset)
+            }
+            setParagraphAttribute(newValue, for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue }
+        }
     }
 
     /// The amount of space between baselines in a block of text.

--- a/FormTests/TextStyleTests.swift
+++ b/FormTests/TextStyleTests.swift
@@ -46,8 +46,8 @@ class TextStyleTests: XCTestCase {
         let font = UIFont.systemFont(ofSize: 14.0)
         var textStyle = TextStyle(font: font, color: .red)
         let initialLineHeight = textStyle.lineHeight
-        textStyle.lineSpacing = 2.0
-        XCTAssertTrue(textStyle.lineHeight > initialLineHeight)
+        textStyle.lineSpacing += 2.0
+        XCTAssertGreaterThan(textStyle.lineHeight, initialLineHeight)
     }
 
     func testIncreasingLineHeightIncreasesLineSpacing() {
@@ -55,6 +55,6 @@ class TextStyleTests: XCTestCase {
         var textStyle = TextStyle(font: font, color: .red)
         let initialLineSpacing = textStyle.lineSpacing
         textStyle.lineHeight += 2.0
-        XCTAssertTrue(textStyle.lineSpacing > initialLineSpacing)
+        XCTAssertGreaterThan(textStyle.lineSpacing, initialLineSpacing)
     }
 }


### PR DESCRIPTION
Fixes a problem introduced in https://github.com/iZettle/Form/pull/92

This is not correct since it doesn't apply the calculation of the new value when being set as line spacing:
```
set { 
    setParagraphAttribute(max(newValue, font.pointSize) - font.lineHeight,  for: .lineSpacing, defaultValue: 0) { $0.lineSpacing = newValue } 
}
````
It is better to use the `lineSpacing` setter directly:
```
set { lineSpacing = max(newValue, font.pointSize) - font.lineHeight }
```

In addition setting negative `lineSpacing` didn't do anything, even though it is persisted it has no effect when a label is rendered for example. Setting the `baselineOffset` to 0 is a workaround, it doesn't do any harm. I think I will work more on the `lineHeight` and provide more examples how it can be used in the future. For now we use this solution or revert the lineHeight at all if there are concerns about it.
