### PR TITLE
Fix label stlying bug

### DIFF
--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		21D7D99F1E1CE95200CB0FE9 /* ValueLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7D99E1E1CE95200CB0FE9 /* ValueLabel.swift */; };
 		3156BAED2139366B00ECC2EC /* MixedReusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3156BAEC2139366B00ECC2EC /* MixedReusable.swift */; };
 		721954D821A44E450090F9E3 /* MinimumSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721954D721A44E450090F9E3 /* MinimumSize.swift */; };
+		724EC30D2241513D001F3E11 /* UILabel+StylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */; };
 		7270AFB0201FAB7C004DAAA3 /* ViewLayoutArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */; };
 		B35F8AEE1F36676D00904E37 /* Collection+Changes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F8AED1F36676D00904E37 /* Collection+Changes.swift */; };
 		B35F8B4C1F3783E400904E37 /* CollectionDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */; };
@@ -135,6 +136,7 @@
 		21D7D99E1E1CE95200CB0FE9 /* ValueLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ValueLabel.swift; path = Form/ValueLabel.swift; sourceTree = "<group>"; };
 		3156BAEC2139366B00ECC2EC /* MixedReusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MixedReusable.swift; path = Form/MixedReusable.swift; sourceTree = "<group>"; };
 		721954D721A44E450090F9E3 /* MinimumSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MinimumSize.swift; path = Form/MinimumSize.swift; sourceTree = "<group>"; };
+		724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+StylingTests.swift"; sourceTree = "<group>"; };
 		7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewLayoutArea.swift; path = Form/ViewLayoutArea.swift; sourceTree = "<group>"; };
 		B35F8AED1F36676D00904E37 /* Collection+Changes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Collection+Changes.swift"; path = "Form/Collection+Changes.swift"; sourceTree = "<group>"; };
 		B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionDiffTests.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */,
 				F604260920B6A47E00BC4CAB /* ParentChildRelationalTests.swift */,
 				F6B81B9320CA906000B6AC39 /* NumberEditorTests.swift */,
+				724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */,
 				F62E45B81CABFB5300C6867E /* Info.plist */,
 			);
 			path = FormTests;
@@ -583,6 +586,7 @@
 				21367C6B1DACDF990021C98F /* TableChangeTests.swift in Sources */,
 				1C2881831F20EE2000666A21 /* SelectViewTests.swift in Sources */,
 				1CDD56AA1D9C10D7004B0CA9 /* TableTests.swift in Sources */,
+				724EC30D2241513D001F3E11 /* UILabel+StylingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -242,6 +242,12 @@ public struct StyledText {
     }
 }
 
+extension StyledText: Equatable {
+    public static func == (lhs: StyledText, rhs: StyledText) -> Bool {
+        return lhs.text.displayValue == rhs.text.displayValue && lhs.style == rhs.style
+    }
+}
+
 public extension StyledText {
     func restyled(_ styler: (inout TextStyle) -> ()) -> StyledText {
         return StyledText(text: text, style: style.restyled(styler))

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -242,12 +242,6 @@ public struct StyledText {
     }
 }
 
-extension StyledText: Equatable {
-    public static func == (lhs: StyledText, rhs: StyledText) -> Bool {
-        return lhs.text.displayValue == rhs.text.displayValue && lhs.style == rhs.style
-    }
-}
-
 public extension StyledText {
     func restyled(_ styler: (inout TextStyle) -> ()) -> StyledText {
         return StyledText(text: text, style: style.restyled(styler))

--- a/Form/UILabel+Styling.swift
+++ b/Form/UILabel+Styling.swift
@@ -91,7 +91,7 @@ private extension UILabel {
         let displayValue = styledText.text.displayValue
         if style.isPlain {
             text = displayValue
-        } else if prevStyledText == styledText, text == displayValue {
+        } else if let prev = prevStyledText, prev.text.displayValue == displayValue, prev.style == style, text == displayValue {
             // The persisted style and the visible text are up-to-date
             // Skipping the recreation of string attributes and applying them
             // If the text attributes were modified manually (they shouldn't be) they won't be reset until the text or the style changes

--- a/Form/UILabel+Styling.swift
+++ b/Form/UILabel+Styling.swift
@@ -10,12 +10,27 @@ import UIKit
 import Flow
 
 public extension UILabel {
+
+    /// Convenience initializer for labels which appearance is controlled by a `TextStyle`.
+    ///
+    /// - Parameter styledText: The text to be presented in the label and the style controlling its appearance
+    ///
+    /// - Note: When using a label with a `TextStyle` you should set all appearance cusomizations through the style,
+    /// e.g color, numberOfLines, attributes etc, to avoid your customizations being overriden by the style and other unexpected results.
     convenience init(styledText: StyledText) {
         self.init()
         setContentHuggingPriority(.required, for: .horizontal)
         setStyledText(styledText)
     }
 
+    /// Convenience initializer for labels which appearance is controlled by a `TextStyle`.
+    ///
+    /// - Parameters:
+    ///   - value: The text to be presented in the label
+    ///   - style: The style controlling the appearance of the label.
+    ///
+    /// - Note: When using a label with a `TextStyle` you should set all appearance cusomizations through the style,
+    /// e.g color, numberOfLines, attributes etc, to avoid your customizations being overriden by the style and other unexpected results.
     convenience init(value: DisplayableString = "", style: TextStyle = .default) {
         self.init(styledText: StyledText(text: value, style: style))
     }
@@ -76,8 +91,10 @@ private extension UILabel {
         let displayValue = styledText.text.displayValue
         if style.isPlain {
             text = displayValue
-        } else if let prev = prevStyledText, displayValue == prev.text.displayValue, style == prev.style {
-            // No update needed
+        } else if prevStyledText == styledText, text == displayValue {
+            // The persisted style and the visible text are up-to-date
+            // Skipping the recreation of string attributes and applying them
+            // If the text attributes were modified manually (they shouldn't be) they won't be reset until the text or the style changes
         } else {
             attributedText = NSAttributedString(styledText: styledText)
         }

--- a/FormTests/UILabel+StylingTests.swift
+++ b/FormTests/UILabel+StylingTests.swift
@@ -1,0 +1,101 @@
+//
+//  UILabel+StylingTests.swift
+//  FormTests
+//
+//  Created by Nataliya Patsovska on 2019-03-19.
+//  Copyright © 2019 iZettle. All rights reserved.
+//
+
+import XCTest
+import Form
+
+class UILabelStylingTests: XCTestCase {
+
+    func testRetrievingLabelStyleAndTextAfterCreation_plainStyle() {
+        let textStyle = TextStyle.plain
+        let randomLabelText = randomText()
+
+        let label = UILabel(value: randomLabelText, style: textStyle)
+
+        XCTAssertEqual(label.style, textStyle)
+        XCTAssertEqual(label.text, randomLabelText)
+        XCTAssertEqual(label.text, label.value.displayValue)
+    }
+
+    func testRetrievingLabelStyleAndTextAfterCreation_styleWithCustomAttributes() {
+        let textStyle = TextStyle.withCustomAttributes
+        let randomLabelText = randomText()
+
+        let label = UILabel(value: randomLabelText, style: textStyle)
+
+        XCTAssertEqual(label.style, textStyle)
+        XCTAssertEqual(label.text, randomLabelText)
+        XCTAssertEqual(label.text, label.value.displayValue)
+    }
+
+    func testSettingSameLabelValueAfterResettingText_plainStyle() {
+        let textStyle = TextStyle.plain
+        let randomLabelText = randomText()
+
+        let label = UILabel(value: randomLabelText, style: textStyle)
+        label.text = nil
+        label.value = randomLabelText
+
+        XCTAssertEqual(label.text, randomLabelText)
+    }
+
+    func testSettingSameLabelValueAfterResettingText_styleWithCustomAttributes() {
+        let textStyle = TextStyle.withCustomAttributes
+        let randomLabelText = randomText()
+
+        let label = UILabel(value: randomLabelText, style: textStyle)
+        label.text = nil
+        label.value = randomLabelText
+
+        XCTAssertEqual(label.text, randomLabelText)
+    }
+
+    func testUpdatingLabelStyle() {
+        let textStyle = TextStyle.plain
+        let randomLabelText = randomText()
+
+        let label = UILabel(value: randomLabelText, style: textStyle)
+        let textStyle2 = TextStyle.withCustomAttributes
+        label.style = textStyle2
+
+        XCTAssertNotEqual(label.style, textStyle)
+        XCTAssertEqual(label.style, textStyle2)
+    }
+
+    func testAssigningStyleToLabelCreatedWithoutStyle() {
+        let label = UILabel(frame: .zero)
+        let textStyle = TextStyle.plain
+
+        label.style = textStyle
+
+        XCTAssertEqual(label.style, textStyle)
+        XCTAssertEqual(label.text, "")
+    }
+
+    func testAssigningStyleToLabelCreatedWithoutStylePreservesText() {
+        let label = UILabel(frame: .zero)
+        let randomLabelText = randomText()
+
+        label.text = randomLabelText
+        let textStyle = TextStyle.plain
+        label.style = textStyle
+
+        XCTAssertEqual(label.style, textStyle)
+        XCTAssertEqual(label.text, randomLabelText)
+    }
+
+    // MARK: - Helpers
+    private func randomText() -> String {
+        return UUID().uuidString
+    }
+}
+
+private extension TextStyle {
+    static let plain = TextStyle(font: .systemFont(ofSize: 14.0), color: .black)
+    static let withCustomAttributes = TextStyle.plain.restyled { $0.letterSpacing = 1.0 }
+}


### PR DESCRIPTION
Even though using `value` instead of `text` is recommended "to not accidentically break styling" using `text` on UILabel is very common and can easily cause bugs hard to track down. This change makes it harder to do so. When using style with custom attributes it is possible to end up in a situation where the label is not showing any text even if its `value` says otherwise. One case like this is covered by `testSettingSameLabelValueAfterResettingText_styleWithCustomAttributes` unit test.