### PR TITLE
Add minimumScaleFactor to TextStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.9.0
+- Add minimum scale factor to TextStyle. When a custom value is set that can also affect other controls using TextStyle, e.g UIButton.
+
 ## 1.8.0
 - Migrate to swift 5
 

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -19,13 +19,14 @@ public struct TextStyle: Style {
 }
 
 public extension TextStyle {
-    init(font: UIFont, color: UIColor, alignment: NSTextAlignment = .natural, numberOfLines: Int = 1, lineBreakMode: NSLineBreakMode = .byTruncatingMiddle) {
+    init(font: UIFont, color: UIColor, alignment: NSTextAlignment = .natural, numberOfLines: Int = 1, lineBreakMode: NSLineBreakMode = .byTruncatingMiddle, minimumScaleFactor: CGFloat = 0) {
         // Don't set attributes directly to make sure lookups such as equatableForAttribute is being correctly updated.
         self.font = font
         self.color = color
         self.numberOfLines = numberOfLines
         self.alignment = alignment
         self.lineBreakMode = lineBreakMode
+        self.minimumScaleFactor = minimumScaleFactor
     }
 }
 
@@ -87,6 +88,11 @@ public extension TextStyle {
     var numberOfLines: Int {
         get { return attribute(for: .numberOfLines) ?? 1 }
         set { setAttribute(newValue == 1 ? nil : newValue, for: .numberOfLines) }
+    }
+
+    var minimumScaleFactor: CGFloat {
+        get { return attribute(for: .minimumScaleFactor) ?? 0 }
+        set { setAttribute(newValue, for: .minimumScaleFactor) }
     }
 
     var highlightedColor: UIColor {
@@ -267,6 +273,7 @@ extension NSAttributedString.Key {
     static let lineBreakMode = NSAttributedString.Key(rawValue: "_lineBreakMode")
     static let lineSpacing = NSAttributedString.Key(rawValue: "_lineSpacing")
     static let textAlignment = NSAttributedString.Key(rawValue: "_textAligment")
+    static let minimumScaleFactor = NSAttributedString.Key(rawValue: "_minimumScaleFactor")
 }
 
 extension TextStyle {
@@ -303,7 +310,9 @@ private extension TextStyle {
 
 private var equatableForAttribute = [NSAttributedString.Key: (Any, Any) -> Bool]()
 private var nextTextStyleChangeIndex = 0
-private let plainAttributes: Set<NSAttributedString.Key> = [.foregroundColor, .font, .numberOfLines, .highlightedColor, .lineBreakMode, .textAlignment]
+private let plainAttributes: Set<NSAttributedString.Key> = [
+    .foregroundColor, .font, .numberOfLines, .highlightedColor, .lineBreakMode, .textAlignment, .minimumScaleFactor
+]
 private var customAttributes = [NSAttributedString.Key: ((NSAttributedString, Any) -> NSAttributedString)]()
 
 private let prototypeCell = UITableViewCell(style: UITableViewCell.CellStyle.value1, reuseIdentifier: nil)

--- a/Form/UILabel+Styling.swift
+++ b/Form/UILabel+Styling.swift
@@ -86,6 +86,8 @@ private extension UILabel {
             numberOfLines = style.numberOfLines
             textAlignment = style.alignment
             lineBreakMode = style.lineBreakMode
+            minimumScaleFactor = style.minimumScaleFactor
+            adjustsFontSizeToFitWidth = style.minimumScaleFactor > 0
         }
 
         let displayValue = styledText.text.displayValue

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Continuation of https://github.com/iZettle/Form/pull/86 .

What has been done?
- Add minimum scale factor to TextStyle. When a custom value is set that can also affect other controls using TextStyle, e.g UIButton.

Version update:
- `minor`, since it adds new functionality in a backwards compatible way

note: looks like the Info plists were not updated for 1.8.0