### PR TITLE
Fix issue with fixed pinning to scrollview of view higher than `minHeight`

### DIFF
--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		721954D821A44E450090F9E3 /* MinimumSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721954D721A44E450090F9E3 /* MinimumSize.swift */; };
 		724EC30D2241513D001F3E11 /* UILabel+StylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */; };
 		7270AFB0201FAB7C004DAAA3 /* ViewLayoutArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */; };
+		72C5ED6F226F432600E32125 /* UIScrollView+PinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */; };
 		B35F8AEE1F36676D00904E37 /* Collection+Changes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F8AED1F36676D00904E37 /* Collection+Changes.swift */; };
 		B35F8B4C1F3783E400904E37 /* CollectionDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */; };
 		CA6755EA1D4B6F1C000662FF /* SegmentedControlStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6755E91D4B6F1C000662FF /* SegmentedControlStyle.swift */; };
@@ -140,6 +141,7 @@
 		721954D721A44E450090F9E3 /* MinimumSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MinimumSize.swift; path = Form/MinimumSize.swift; sourceTree = "<group>"; };
 		724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+StylingTests.swift"; sourceTree = "<group>"; };
 		7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewLayoutArea.swift; path = Form/ViewLayoutArea.swift; sourceTree = "<group>"; };
+		72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+PinningTests.swift"; sourceTree = "<group>"; };
 		B35F8AED1F36676D00904E37 /* Collection+Changes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Collection+Changes.swift"; path = "Form/Collection+Changes.swift"; sourceTree = "<group>"; };
 		B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionDiffTests.swift; sourceTree = "<group>"; };
 		CA6755E91D4B6F1C000662FF /* SegmentedControlStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SegmentedControlStyle.swift; path = Form/SegmentedControlStyle.swift; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				F604260920B6A47E00BC4CAB /* ParentChildRelationalTests.swift */,
 				F6B81B9320CA906000B6AC39 /* NumberEditorTests.swift */,
 				724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */,
+				72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */,
 				F62E45B81CABFB5300C6867E /* Info.plist */,
 			);
 			path = FormTests;
@@ -588,6 +591,7 @@
 				5B4ABD3A2257365C0073FACE /* TableKitTests.swift in Sources */,
 				CDD2A5211F42DE7500E2B78B /* HighlightedTests.swift in Sources */,
 				B35F8B4C1F3783E400904E37 /* CollectionDiffTests.swift in Sources */,
+				72C5ED6F226F432600E32125 /* UIScrollView+PinningTests.swift in Sources */,
 				21367C6B1DACDF990021C98F /* TableChangeTests.swift in Sources */,
 				1C2881831F20EE2000666A21 /* SelectViewTests.swift in Sources */,
 				1CDD56AA1D9C10D7004B0CA9 /* TableTests.swift in Sources */,

--- a/FormTests/UIScrollView+PinningTests.swift
+++ b/FormTests/UIScrollView+PinningTests.swift
@@ -1,0 +1,87 @@
+//
+//  Copyright © 2019 iZettle. All rights reserved.
+//
+
+import XCTest
+import Form
+import Flow
+
+class UIScrollViewPinningTests: XCTestCase {
+    func testPinningWithMinHeight_finalViewHeightHigherThanMinHeight() {
+        verifyPinningViewToTopAndToBottom(initialViewMinimumHeight: 200,
+                                          pinningMinimumHeight: 100,
+                                          expectedHeight: 200)
+    }
+
+    func testPinningWithMinHeight_finalViewHeightEqualToMinHeight() {
+        verifyPinningViewToTopAndToBottom(initialViewMinimumHeight: 200,
+                                          pinningMinimumHeight: 400,
+                                          expectedHeight: 400)
+    }
+
+    func testPinningWithMinHeight_finalViewHeightHigherThanMinHeight_afterHeighUpdate() {
+        verifyPinningViewToTopAndToBottom(initialViewMinimumHeight: 0,
+                                          finalViewMinimumHeight: 200,
+                                          pinningMinimumHeight: 100,
+                                          expectedHeight: 200)
+    }
+
+    func testPinningWithMinHeight_finalViewHeightEqualToMinHeight_afterHeighUpdate() {
+        verifyPinningViewToTopAndToBottom(initialViewMinimumHeight: 1000,
+                                          finalViewMinimumHeight: 200,
+                                          pinningMinimumHeight: 400,
+                                          expectedHeight: 400)
+    }
+
+    // MARK: - Helpers
+    func verifyPinningViewToTopAndToBottom(initialViewMinimumHeight: CGFloat,
+                                           finalViewMinimumHeight: CGFloat? = nil,
+                                           pinningMinimumHeight: CGFloat,
+                                           expectedHeight: CGFloat,
+                                           file: StaticString = #file,
+                                           line: UInt = #line) {
+        for edge in UIScrollView.PinEdge.allCases {
+            verifyViewPinning(to: edge,
+                              initialViewMinimumHeight: initialViewMinimumHeight,
+                              finalViewMinimumHeight: finalViewMinimumHeight,
+                              pinningMinimumHeight: pinningMinimumHeight,
+                              expectedHeight: expectedHeight,
+                              file: file,
+                              line: line)
+        }
+    }
+
+    private func verifyViewPinning(to edge: UIScrollView.PinEdge,
+                                   initialViewMinimumHeight: CGFloat,
+                                   finalViewMinimumHeight: CGFloat? = nil,
+                                   pinningMinimumHeight: CGFloat,
+                                   expectedHeight: CGFloat,
+                                   file: StaticString = #file,
+                                   line: UInt = #line) {
+        // Given
+        let viewToEmbed = UIView()
+        let heightConstraint: NSLayoutConstraint = viewToEmbed.heightAnchor >= initialViewMinimumHeight
+        activate(heightConstraint)
+
+        let (scrollView, _) = makeEmbeddedScrollView(size: CGSize(width: expectedHeight * 2, height: expectedHeight * 2))
+
+        // When
+        let disposable = scrollView.embedPinned(viewToEmbed, edge: edge, minHeight: pinningMinimumHeight)
+        if let finalViewMinimumHeight = finalViewMinimumHeight {
+            heightConstraint.constant = finalViewMinimumHeight
+            viewToEmbed.setNeedsLayout()
+            viewToEmbed.layoutIfNeeded()
+        }
+
+        // Then
+        XCTAssertEqual(viewToEmbed.frame.size.height, expectedHeight, "pinning to `\(edge)`", file: file, line: line)
+        disposable.dispose()
+    }
+
+    private func makeEmbeddedScrollView(size: CGSize) -> (UIScrollView, UIView) {
+        let scrollView = UIScrollView()
+        let container = UIView(embeddedView: scrollView)
+        container.frame = CGRect(origin: .zero, size: size)
+        return (scrollView, container)
+    }
+}


### PR DESCRIPTION
Fixing https://github.com/iZettle/Form/issues/104 by basically copying the iOS 11+ minHeight solution which seems to work.

Added some unit tests for the pinning that failed initially and now pass but I also tested on a device running iOS 10.2.

We should probably discuss the option of deprecating `.spring` and `.loose` pinnings as they are neither used nor tested and running tests on iOS 10.