### PR TITLE
Add priority to MinimumSize and use it in ButtonStyle

### DIFF
--- a/Form/ButtonStyle.swift
+++ b/Form/ButtonStyle.swift
@@ -147,14 +147,14 @@ private extension UIButton {
     }
 
     func updateMinimumSize(_ minimumSize: MinimumSize) {
-        updateConstraint(for: widthAnchor, with: minimumSize.width, constraintKey: &widthConstraintKey)
-        updateConstraint(for: heightAnchor, with: minimumSize.height, constraintKey: &heightConstraintKey)
+        updateConstraint(for: widthAnchor, with: minimumSize.width, priority: minimumSize.priority, constraintKey: &widthConstraintKey)
+        updateConstraint(for: heightAnchor, with: minimumSize.height, priority: minimumSize.priority, constraintKey: &heightConstraintKey)
     }
 
-    func updateConstraint(for anchor: NSLayoutDimension, with value: CGFloat?, constraintKey key: UnsafeRawPointer) {
+    func updateConstraint(for anchor: NSLayoutDimension, with value: CGFloat?, priority: UILayoutPriority, constraintKey key: UnsafeRawPointer) {
         let constant = value ?? 0
         let constraint = associatedValue(forKey: key, initial: anchor >= constant)
-        constraint.priority = .defaultHigh
+        constraint.priority = priority
         constraint.constant = constant
         constraint.isActive = (value != nil)
     }

--- a/Form/MinimumSize.swift
+++ b/Form/MinimumSize.swift
@@ -10,10 +10,12 @@ import Foundation
 public struct MinimumSize: Style {
     public var width: CGFloat?
     public var height: CGFloat?
+    public var priority: UILayoutPriority
 
-    public init(width: CGFloat? = nil, height: CGFloat? = nil) {
+    public init(width: CGFloat? = nil, height: CGFloat? = nil, priority: UILayoutPriority = .defaultHigh) {
         self.width = width
         self.height = height
+        self.priority = priority
     }
 }
 


### PR DESCRIPTION
Specify the priority of a `MinimumSize` instance so that it can be used when setting up constraints.

Note: I considered whether the priority should be set separately for width and height but this will lead to an API breaking change and there is no use case for it at the moment so I decided not to do it. If in the future there is a case for that, we can change it.