### PR TITLE
Remove bag parameter from TableKit and CollectionKit

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,7 @@ disabled_rules:
   - void_return
   - trailing_comma
   - shorthand_operator
+  - unused_closure_parameter
 
 opt_in_rules:
   - first_where

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,8 @@ disabled_rules:
   - file_length
   - line_length
   - function_body_length
+  - function_parameter_count
+  - large_tuple
 
   - nesting
   - cyclomatic_complexity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.0
+- `TableKit` and `CollectionKit` do no longer require the passing of a bag to their initializers. This means that the life-time of a kit instance is no longer kept alive by a provided bag. For most usages that should not change the behaviour but if the kit is prematurly deallocted you can always explicity hold on to it `bag.hold(kit)`.
+- `TableKit`'s and `CollectionKit`'s initializers taking a bag parameter have been deprecated. Instead use the new initializers introduced above.
+
 ## 1.9.0
 - Bugfix: Make sure to remove the old empty state view from a table after setting a new empty state view [#99](https://github.com/iZettle/Form/issues/99).
 - Add minimum scale factor to TextStyle. When a custom value is set that can also affect other controls using TextStyle, e.g UIButton.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.10.0
-- `TableKit` and `CollectionKit` do no longer require the passing of a bag to their initializers. This means that the life-time of a kit instance is no longer kept alive by a provided bag. For most usages that should not change the behaviour but if the kit is prematurly deallocted you can always explicity hold on to it `bag.hold(kit)`.
+- `TableKit` and `CollectionKit` do no longer require the passing of a bag to their initializers. This means that the life-time of a kit instance is no longer kept alive by a provided bag. For most usages that should not change the behaviour but if the kit is prematurely deallocted you can always explicity hold on to it `bag.hold(kit)`.
 - `TableKit`'s and `CollectionKit`'s initializers taking a bag parameter have been deprecated. Instead use the new initializers introduced above.
 
 ## 1.9.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "iZettle/Flow" ~> 1.7
+github "iZettle/Flow" ~> 1.8

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "iZettle/Flow" "1.7.0"
+github "iZettle/Flow" "1.8.0"

--- a/Examples/Demo/Example/Messages.swift
+++ b/Examples/Demo/Example/Messages.swift
@@ -61,7 +61,7 @@ extension UIViewController {
         displayableTitle = "Messages"
         let bag = DisposeBag()
 
-        let tableKit = TableKit<EmptySection, Message>(bag: bag)
+        let tableKit = TableKit<EmptySection, Message>()
 
         bag += messages.atOnce().onValue {
             tableKit.set(Table(rows: $0))

--- a/Examples/Demo/Example/Tables.swift
+++ b/Examples/Demo/Example/Tables.swift
@@ -30,7 +30,7 @@ extension UIViewController {
         displayableTitle = "TableKit"
         let bag = DisposeBag()
 
-        let tableKit = TableKit(table: table, style: style, bag: bag, headerForSection: { table, item in
+        let tableKit = TableKit(table: table, style: style, headerForSection: { table, item in
             table.dequeueHeaderFooterView(forItem: item) { reuseIdentifier in
                 let label = UILabel()
                 let header = UITableViewHeaderFooterView(view: label, style: style.header, formStyle: style.form, reuseIdentifier: reuseIdentifier)
@@ -64,7 +64,7 @@ extension UIViewController {
         displayableTitle = "TableKit and Reusable"
         let bag = DisposeBag()
 
-        let tableKit = TableKit(table: table, style: style, bag: bag)
+        let tableKit = TableKit(table: table, style: style)
         bag += self.install(tableKit.view)
 
         bag += self.navigationItem.addItem(UIBarButtonItem(title: "Swap"), position: .right).onValue {
@@ -79,7 +79,7 @@ extension UIViewController {
         displayableTitle = "TableKit with Form Header"
         let bag = DisposeBag()
 
-        let tableKit = TableKit(table: table, style: style, bag: bag)
+        let tableKit = TableKit(table: table, style: style)
 
         let form = FormView(style: style.form.openedBottom)
         let section = form.appendSection(header: "Forms Section", style: style.section)
@@ -105,7 +105,7 @@ extension UIViewController {
         var table = Table(rows: 0..<7)
         var swapTable = Table(rows: 4..<12)
 
-        let tableKit = TableKit(table: table, style: style.openedTop, bag: bag)
+        let tableKit = TableKit(table: table, style: style.openedTop)
 
         let form = FormView(style: style.form.openedBottom)
         let section = form.appendSection(header: "Forms Section", style: style.section.openedBottom)
@@ -137,7 +137,7 @@ extension UIViewController {
             ("Header 1b", [.left(1), .right("D"), .right("F"), .left(6)]),
             ("Header 2", [.left(3), .right("A"), .left(4), .right("E")])])
 
-        let tableKit = TableKit(table: table, style: style, bag: bag)
+        let tableKit = TableKit(table: table, style: style)
         bag += self.install(tableKit.view)
 
         bag += self.navigationItem.addItem(UIBarButtonItem(title: "Swap"), position: .right).onValue {
@@ -161,7 +161,7 @@ extension UIViewController {
             ("Header 1b", [.init(1), .init("D"), .init("F"), .init(6.66)]),
             ("Header 2", [.init(3.14), .init("A"), .init(4), .init("E")])])
 
-        let tableKit = TableKit(table: table, style: style, bag: bag)
+        let tableKit = TableKit(table: table, style: style)
         bag += self.install(tableKit.view)
 
         bag += self.navigationItem.addItem(UIBarButtonItem(title: "Swap"), position: .right).onValue {
@@ -185,7 +185,7 @@ extension UIViewController {
             [.left(.right("A")), .right(3.14), .left(.left(1)), .right(47.11) ]
         )
 
-        let tableKit = TableKit(table: table, style: style, bag: bag)
+        let tableKit = TableKit(table: table, style: style)
         bag += self.install(tableKit.view)
 
         bag += self.navigationItem.addItem(UIBarButtonItem(title: "Swap"), position: .right).onValue {
@@ -200,7 +200,7 @@ extension UIViewController {
         displayableTitle = "TableKit and HeaderFooterReusable"
         let bag = DisposeBag()
 
-        let tableKit = TableKit(table: sectionTable, style: style, bag: bag)
+        let tableKit = TableKit(table: sectionTable, style: style)
         bag += self.install(tableKit.view)
 
         bag += self.navigationItem.addItem(UIBarButtonItem(title: "Swap"), position: .right).onValue {

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.0</string>
+	<string>1.10.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Form/SectionView.swift
+++ b/Form/SectionView.swift
@@ -198,9 +198,7 @@ private extension SectionView {
         var synchronizedHides = [(() -> ())]()
 
         for row in rows {
-            hiddenBag += row.content.signal(for: \.isHidden).onValue { [weak self] hidden in
-                guard let `self` = self else { return }
-
+            hiddenBag += row.content.signal(for: \.isHidden).with(weak: self).onValue { hidden, `self` in
                 let action = {
                     row.select.isHidden = hidden
                     self.applyStyling()

--- a/Form/SelectView.swift
+++ b/Form/SelectView.swift
@@ -40,8 +40,8 @@ public final class SelectView: UIView, Selectable, Highlightable {
         super.didMoveToWindow()
         bag.dispose()
         if window != nil { // in didMoveToWindow to break any retain cycles when the view is removed
-            bag += Flow.combineLatest(isSelectedSignal.atOnce(), isHighlightedSignal.atOnce()).onValue { [weak self] _, _ in
-                self?.updateCurrentState()
+            bag += Flow.combineLatest(isSelectedSignal.atOnce(), isHighlightedSignal.atOnce()).with(weak: self).onValue { _, _, `self` in
+                self.updateCurrentState()
             }
         }
     }

--- a/Form/UITableViewCell+Utilities.swift
+++ b/Form/UITableViewCell+Utilities.swift
@@ -45,10 +45,9 @@ public extension UITableViewCell {
         setAssociatedValue((view, heightConstraint, bag, updateInsets), forKey: &tableFormKey)
 
         // Getting signal from contentView instead of self to avoid retain cycle between self and bag
-        bag += contentView.traitCollectionWithFallbackSignal.distinct().atOnce().onValue { [weak self] traits in
-            guard let strongSelf = self else { return }
+        bag += contentView.traitCollectionWithFallbackSignal.with(weak: self as UITableViewCell).onValue { traits, `self` in
             let style = style.style(from: traits)
-            strongSelf.applyFormStyle(style)
+            self.applyFormStyle(style)
         }
     }
 }

--- a/Form/ValueField.swift
+++ b/Form/ValueField.swift
@@ -112,14 +112,13 @@ public final class ValueField<Value>: UIControl, UIKeyInput {
         applyStyle()
         updateText()
 
-        bag += NotificationCenter.default.signal(forName: UIApplication.didBecomeActiveNotification).onValue { [weak self] _ in
-            self?.installAnimation() // When app is deactivated, running animations are removed. Let's re-install it.
+        bag += NotificationCenter.default.signal(forName: UIApplication.didBecomeActiveNotification).with(weak: self).onValue { _, `self` in
+            self.installAnimation() // When app is deactivated, running animations are removed. Let's re-install it.
         }
 
         let longPressGesture = UILongPressGestureRecognizer()
         addGestureRecognizer(longPressGesture)
-        bag += longPressGesture.signal(forState: .began).onValue { [weak self] in
-            guard let `self` = self else { return }
+        bag += longPressGesture.signal(forState: .began).with(weak: self).onValue { `self` in
             let menuController = UIMenuController.shared
             menuController.setTargetRect(self.bounds, in: self)
             menuController.setMenuVisible(true, animated: true)

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.9.0"
+  s.version      = "1.10.0"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { 'iZettle AB' => 'hello@izettle.com' }
 
   s.ios.deployment_target = "9.0"
-  s.dependency 'FlowFramework', '~> 1.3'
+  s.dependency 'FlowFramework', '~> 1.8'
   s.default_subspec = 'Form'
 
   s.subspec 'Form' do |form|

--- a/FormTests/TableChangeTests.swift
+++ b/FormTests/TableChangeTests.swift
@@ -133,7 +133,7 @@ class TableChangeTests: XCTestCase {
         var prevs = [Int?]()
         bag += signal.onValue { prevs.append($0) }
 
-        let tableKit = TableKit<(), ReconfigureItem>(bag: bag)
+        let tableKit = TableKit<(), ReconfigureItem>()
         UIWindow().addSubview(tableKit.view)
         tableKit.view.frame.size = CGSize(width: 1000, height: 1000)
 

--- a/FormTests/TableChangeTests.swift
+++ b/FormTests/TableChangeTests.swift
@@ -27,12 +27,12 @@ class TableChangeTests: XCTestCase {
 
     func test<R: Hashable, S: Hashable>(from: Table<R, S>, to: Table<R, S>) {
 
-        let tableView = TableKit(table: from, bag: bag) { _, _ in UITableViewCell() }
+        let tableView = TableKit(table: from) { _, _ in UITableViewCell() }
         tableView.view.frame = window.bounds
         window.addSubview(tableView.view)
         tableView.view.reloadData()
 
-        let collectionView = CollectionKit(table: from, layout: UICollectionViewFlowLayout(), bag: bag) { (view, row, index) -> UICollectionViewCell in
+        let collectionView = CollectionKit(table: from, layout: UICollectionViewFlowLayout()) { (view, row, index) -> UICollectionViewCell in
             view.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "id")
             return view.dequeueCell(withReuseIdentifier: "id", for: IndexPath(row: index.row, section: index.section))
         }

--- a/FormTests/TableKitTests.swift
+++ b/FormTests/TableKitTests.swift
@@ -7,11 +7,10 @@ import Flow
 @testable import Form
 
 class TableKitTests: XCTestCase {
-
     func testEmptyStateView_setNewView_oldViewIsRemoved() {
         let bag = DisposeBag()
         let emptyTable: Table<Int, Int> = Table(sections: [(1, [])])
-        let tableView = TableKit(table: emptyTable, bag: bag) { _, _ in UITableViewCell() }
+        let tableView = TableKit(table: emptyTable) { _, _ in UITableViewCell() }
 
         let oldEmptyStateView = UIView()
         bag += tableView.viewForEmptyTable(fadeDuration: 0).set { _ in
@@ -37,7 +36,7 @@ class TableKitTests: XCTestCase {
     func testEmptyStateView_setNewView_oldViewIsRemoved_NoCache() {
         let bag = DisposeBag()
         let emptyTable: Table<Int, Int> = Table(sections: [(1, [])])
-        let tableView = TableKit(table: emptyTable, bag: bag) { _, _ in UITableViewCell() }
+        let tableView = TableKit(table: emptyTable) { _, _ in UITableViewCell() }
 
         let oldEmptyStateView = UIView()
         let viewForEmptyTable = tableView.viewForEmptyTable()
@@ -56,4 +55,19 @@ class TableKitTests: XCTestCase {
         XCTAssertNil(oldEmptyStateView.superview)
     }
 
+    func testTableKitNoRetainCycles() {
+        var kit: TableKit! = TableKit(table: Table(rows: [1, 2])) { _, _ in UITableViewCell() }
+        weak var weakKit = kit
+        XCTAssertNotNil(weakKit)
+        kit = nil
+        XCTAssertNil(weakKit)
+    }
+
+    func testCollectionKitNoRetainCycles() {
+        var kit: CollectionKit! = CollectionKit(table: Table(rows: [1, 2]), layout: UICollectionViewFlowLayout()) { _, _, _ in UICollectionViewCell() }
+        weak var weakKit = kit
+        XCTAssertNotNil(weakKit)
+        kit = nil
+        XCTAssertNil(weakKit)
+    }
 }


### PR DESCRIPTION
- `TableKit` and `CollectionKit` do no longer require the passing of a bag to their initializers. This means that the life-time of a kit instance is no longer kept alive by a provided bag. For most usages that should not change the behaviour but if the kit is prematurly deallocted you can always explicity hold on to it `bag.hold(kit)`.

- `TableKit`'s and `CollectionKit`'s initializers taking a bag parameter have been deprecated. Instead use the new initializers introduced above.

For some background to this change see: https://github.com/iZettle/Flow/issues/82#issuecomment-487576883