### PR TITLE
Fix multiline row view titles

### DIFF
--- a/Examples/Demo/Example.xcodeproj/project.pbxproj
+++ b/Examples/Demo/Example.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		4C9844A20B25AB01E6B23F2B /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2511AB6F393DD3F7D3FBC2D5 /* Pods_Example.framework */; };
+		72531025228C5FFC0008B5E2 /* MultilineRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72531024228C5FFC0008B5E2 /* MultilineRows.swift */; };
 		F652911320CFC6DF002D665A /* Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F652911220CFC6DF002D665A /* Messages.swift */; };
 		F684177620CE7CCD00AA4E35 /* CustomStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F684177520CE7CCD00AA4E35 /* CustomStyle.swift */; };
 		F6B3E0592086210E00F55C53 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B3E0582086210E00F55C53 /* AppDelegate.swift */; };
@@ -34,6 +35,7 @@
 		2511AB6F393DD3F7D3FBC2D5 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4237EFB1C03450B25AC9AF19 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
 		680BD49AB995FEECA6DBEE15 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
+		72531024228C5FFC0008B5E2 /* MultilineRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineRows.swift; sourceTree = "<group>"; };
 		F652911220CFC6DF002D665A /* Messages.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
 		F684177520CE7CCD00AA4E35 /* CustomStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomStyle.swift; sourceTree = "<group>"; };
 		F6B3E0552086210E00F55C53 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -89,6 +91,7 @@
 			children = (
 				F6B3E0582086210E00F55C53 /* AppDelegate.swift */,
 				F6F6797A20A2DF0A004C7AA7 /* Contents.swift */,
+				72531024228C5FFC0008B5E2 /* MultilineRows.swift */,
 				F6F0210F20AD59E40035511D /* Tables.swift */,
 				F6B81B9520CAA2A200B6AC39 /* Values.swift */,
 				F652911220CFC6DF002D665A /* Messages.swift */,
@@ -221,6 +224,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F684177620CE7CCD00AA4E35 /* CustomStyle.swift in Sources */,
+				72531025228C5FFC0008B5E2 /* MultilineRows.swift in Sources */,
 				F6B3E0592086210E00F55C53 /* AppDelegate.swift in Sources */,
 				F6F0211020AD59E40035511D /* Tables.swift in Sources */,
 				F652911320CFC6DF002D665A /* Messages.swift in Sources */,

--- a/Examples/Demo/Example/Contents.swift
+++ b/Examples/Demo/Example/Contents.swift
@@ -57,6 +57,10 @@ extension UIViewController {
             present { $0.presentValues() }
         }
 
+        bag += form.appendSection().appendRow(title: "Multiline rows").append(.chevron).onValueDisposePrevious {
+            present { $0.presentMultilineRows() }
+        }
+
         let messages = ReadWriteSignal(testMessages)
         bag += form.appendSection().appendRow(title: "Messages").append(.chevron).onValueDisposePrevious {
             present { messagesController in

--- a/Examples/Demo/Example/MultilineRows.swift
+++ b/Examples/Demo/Example/MultilineRows.swift
@@ -1,0 +1,43 @@
+//
+//  MultilineRows.swift
+//  Example
+//
+//  Created by Nataliya Patsovska on 2019-05-15.
+//  Copyright © 2019 iZettle. All rights reserved.
+//
+
+import UIKit
+import Flow
+import Form
+
+extension UIViewController {
+    func presentMultilineRows() -> Disposable {
+        let shortTitle = "Short title"
+        let shortSubtitle = "Short subtitle"
+        let longTitle = "Long title that goes on multiple lines and has \nline break"
+        let longSubtitle = "Long subtitle that goes on multiple lines and has \nline break"
+
+        let style = TitleSubtitleStyle.default.restyled {
+            $0.title = $0.title.multilined()
+            $0.subtitle = $0.subtitle.multilined()
+        }
+
+        self.displayableTitle = "Test multiline rows"
+
+        let form = FormView()
+        let section = form.appendSection()
+
+        section.appendRow(title: shortTitle, style: style.title).prepend("1")
+        section.appendRow(title: longTitle, style: style.title).prepend("2")
+
+        section.appendRow(title: shortTitle, subtitle: shortSubtitle, style: style).prepend("3")
+        section.appendRow(title: shortTitle, subtitle: longSubtitle, style: style).prepend("4")
+        section.appendRow(title: longTitle, subtitle: shortSubtitle, style: style).prepend("5")
+        section.appendRow(title: longTitle, subtitle: longSubtitle, style: style).prepend("6")
+
+        section.appendRow(title: longTitle, style: style.title).append(UISwitch()).prepend("7")
+        section.appendRow(title: longTitle, subtitle: longSubtitle, style: style).append(UISwitch()).prepend("8")
+
+        return self.install(form)
+    }
+}

--- a/Form/RowView.swift
+++ b/Form/RowView.swift
@@ -48,10 +48,8 @@ public extension RowView {
     /// - Parameters:
     ///    - appendSpacer: Whether a `.spacer` we should be appended to move succeeding views to the right. Defaults to true.
     convenience init(title: DisplayableString, style: TextStyle = TitleSubtitleStyle.default.title, appendSpacer: Bool = true) {
-        let titleLabel = UILabel(value: title, style: style)
-        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-        self.init([ titleLabel ] + (appendSpacer ? [.spacer] : []), titleLabel: titleLabel)
+        let titleSubtitleStyle = TitleSubtitleStyle.default.restyled { $0.title = style }
+        self.init(title: title, subtitle: "", style: titleSubtitleStyle, appendSpacer: appendSpacer)
     }
 
     /// Creates new instance with a stackview show a title at the top and subtile at the bottom


### PR DESCRIPTION
We use a lot of stack views in Form. In particular `RowView` is a stack view subclass and we use it as a horizontal container for various subviews. `RowView` provides few convenience initializers for laying out a title and a subtitle using a particular `TextStyle`. In the cases when we pass a text style that is configured for multiline text `RowView` doesn't always handle the layout correctly (see the image below). This is to a big extent because stack views add their own constraints like mentioned in [this great article](https://useyourloaf.com/blog/stack-views-and-multi-line-labels):
> The infamous (and undocumented) UISV-text-width-disambiguation constraint is the interesting one:
label.width = 0.5 * stackView.width - 0 @ 759

It is important for rows to support multiline text as any application that supports different languages and dynamic type needs this feature. I considered few different approaches and this one seems like the least invasive. Basically when a label is wrapped in a container view, stack view doesn't add this magical constraint..

I added an example to the Demo project that illustrates the problem and can be used for testing other solutions as well. This is how it looks:

<img width="461" alt="Screenshot 2019-05-15 at 17 22 02" src="https://user-images.githubusercontent.com/1555713/57788946-48841380-7738-11e9-9f6a-566bf84c3dac.png">

