### PR TITLE
Bump version to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.1
+- Bugfix: fix pinning a view to a scrollview on iOS 9 and 10 (issue [#104](https://github.com/iZettle/Form/issues/104))
+- Layout fix: properly layout multiline row view titles
+
 ## 1.9.0
 - Bugfix: Make sure to remove the old empty state view from a table after setting a new empty state view [#99](https://github.com/iZettle/Form/issues/99).
 - Add minimum scale factor to TextStyle. When a custom value is set that can also affect other controls using TextStyle, e.g UIButton.

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.0</string>
+	<string>1.9.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.9.0"
+  s.version      = "1.9.1"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.0</string>
+	<string>1.9.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- Bugfix: fix pinning a view to a scrollview on iOS 9 and 10 (issue [#104](https://github.com/iZettle/Form/issues/104))
- Layout fix: properly layout multiline row view titles