### PR TITLE
Apply view styling based on initial traits and bump Form to 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.10.1
+- Bugfix: Apply view styling based on initial trait collection to prevent bugs where styling is not applied if the initial trait collection did not change
+
 ## 1.10.0
 - `TableKit` and `CollectionKit` do no longer require the passing of a bag to their initializers. This means that the life-time of a kit instance is no longer kept alive by a provided bag. For most usages that should not change the behaviour but if the kit is prematurely deallocted you can always explicity hold on to it `bag.hold(kit)`.
 - `TableKit`'s and `CollectionKit`'s initializers taking a bag parameter have been deprecated. Instead use the new initializers introduced above.

--- a/Form/FormView.swift
+++ b/Form/FormView.swift
@@ -20,6 +20,8 @@ public class FormView: UIStackView, DynamicStylable {
         axis = .vertical
         distribution = .fill
         alignment = .fill
+
+        applyStylingIfNeeded()
     }
 
     public required init(coder: NSCoder) {

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.0</string>
+	<string>1.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Form/SectionView.swift
+++ b/Form/SectionView.swift
@@ -45,6 +45,8 @@ public class SectionView: UIView {
 
         self.updateOrderedViews(to: rows)
         orderedViews = rows
+
+        applyStylingIfNeeded()
     }
 
     required public init(coder: NSCoder) {

--- a/Form/UITableViewCell+Utilities.swift
+++ b/Form/UITableViewCell+Utilities.swift
@@ -45,7 +45,7 @@ public extension UITableViewCell {
         setAssociatedValue((view, heightConstraint, bag, updateInsets), forKey: &tableFormKey)
 
         // Getting signal from contentView instead of self to avoid retain cycle between self and bag
-        bag += contentView.traitCollectionWithFallbackSignal.with(weak: self as UITableViewCell).onValue { traits, `self` in
+        bag += contentView.traitCollectionWithFallbackSignal.distinct().atOnce().with(weak: self as UITableViewCell).onValue { traits, `self` in
             let style = style.style(from: traits)
             self.applyFormStyle(style)
         }

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.10.0"
+  s.version      = "1.10.1"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { 'iZettle AB' => 'hello@izettle.com' }
 
   s.ios.deployment_target = "9.0"
-  s.dependency 'FlowFramework', '~> 1.8'
+  s.dependency 'FlowFramework', '~> 1.8.2'
   s.default_subspec = 'Form'
 
   s.subspec 'Form' do |form|

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.1</string>
+	<string>1.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
iOS 13 changes the way trait collection is determined. `traitCollectionDidChange` is no longer guaranteed to be called and that also makes `traitCollectionWithFallbackSignal` not guaranteed so any styling that relies on traits needs to be taken care of on initialization as well.

Depends on: https://github.com/iZettle/Flow/pull/91