### PR TITLE
Remove wrong scrollview top pinning constant on iOS 11, leftover from iOS 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.10.2
+- Bugfix: Fix scrollview top pinning on iOS 11 and later where currently if the scrollview is in a navigation controller there is a gap between the scrollview top and the pinned view 
+
 ## 1.10.1
 - Bugfix: Apply view styling based on initial trait collection to prevent bugs where styling is not applied if the initial trait collection did not change
 

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.1</string>
+	<string>1.10.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -107,12 +107,10 @@ public extension UIScrollView {
             switch pinning {
             case .spring:
                 fix = view.topAnchor == frameLayoutGuide.topAnchor
-                fix?.constant = frame.origin.y
                 fix?.priority -= 1
                 spring = view.bottomAnchor <= topAnchor
             case .fixed:
                 fix = view.topAnchor == frameLayoutGuide.topAnchor
-                fix?.constant = frame.origin.y
                 spring = nil
             case .loose:
                 fix = nil

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.10.1"
+  s.version      = "1.10.2"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.1</string>
+	<string>1.10.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
The content insets behaviour on iOS 10 was weird, the insets of the scrollview by default included the nav bar adjustment because the scrollviews would go below the navigation bars but there was no good way to get only those insets without the custom set insets. I guess the iOS 10 pinning solution accomodates for that using the `frame.origin.y` as a constant for the pinned view constraint. That assumes the scrollview is always placed at the top of the screen. This PR doesn't address this logic that can be potentially causing bugs for some users.

On iOS  11 we use the `frameLayoutGuide` which takes into account the safe area and bars so using the originY of the scrollview as a constraint constant causes a gap between the pinned view and the navigation bar.