### PR TITLE
Build and test on iOS 12 and 13 in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,10 @@
 version: 2
+
 env:
   global:
-  - LC_CTYPE=en_US.UTF-8
-  - LANG=en_US.UTF-8
+    - LC_CTYPE=en_US.UTF-8
+    - LANG=en_US.UTF-8
+
 jobs:
   swiftlint:
     docker:
@@ -24,6 +26,22 @@ jobs:
             xcodebuild -showsdks
             swift -version
             sh build.sh test-iOS
+
+  test-iOS12:
+    macos:
+      xcode: "10.2.0"
+    steps:
+      - checkout
+      - run:
+          name: test iOS
+          command: |
+            set -o pipefail
+            xcodebuild -version
+            xcodebuild -showsdks
+            swift -version
+            IOS_SDK="iphonesimulator12.2" \
+                IOS_DESTINATION_PHONE="OS=12.2,name=iPhone Xs" \
+                sh build.sh test-iOS
 
   examples:
     macos:
@@ -47,7 +65,10 @@ workflows:
       - swiftlint
       - test-iOS:
           requires:
-          - swiftlint
+            - swiftlint
+      - test-iOS12:
+          requires:
+            - swiftlint
       - examples:
           requires:
-          - swiftlint
+            - swiftlint

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,8 @@ set -o pipefail
 PROJECT="Form.xcodeproj"
 SCHEME="Form"
 
-IOS_SDK="iphonesimulator13.0"
-IOS_DESTINATION="OS=13.0,name=iPhone Xs"
+IOS_SDK="${IOS_SDK:-"iphonesimulator13.0"}"
+IOS_DESTINATION_PHONE="${IOS_DESTINATION_PHONE:-"OS=13.0,name=iPhone Xs"}"
 
 usage() {
 cat << EOF
@@ -43,7 +43,7 @@ case "$COMMAND" in
     -project $PROJECT \
     -scheme "${SCHEME}" \
     -sdk "${IOS_SDK}" \
-    -destination "${IOS_DESTINATION}" \
+    -destination "${IOS_DESTINATION_PHONE}" \
     -configuration Debug ONLY_ACTIVE_ARCH=YES \
     CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
     build | xcpretty -c
@@ -59,7 +59,7 @@ case "$COMMAND" in
           -workspace "${example}Example.xcworkspace" \
           -scheme Example \
           -sdk "${IOS_SDK}" \
-          -destination "${IOS_DESTINATION}" \
+          -destination "${IOS_DESTINATION_PHONE}" \
           build | xcpretty -c
     done
     exit 0
@@ -71,7 +71,7 @@ case "$COMMAND" in
     -project $PROJECT \
     -scheme "${SCHEME}" \
     -sdk "${IOS_SDK}" \
-    -destination "${IOS_DESTINATION}" \
+    -destination "${IOS_DESTINATION_PHONE}" \
     -configuration Debug \
     ONLY_ACTIVE_ARCH=YES \
     CODE_SIGNING_REQUIRED=NO \


### PR DESCRIPTION
Enable building and running on iOS 12 and 13 in parallel to prevent regressions.