### PR TITLE
Fix a problem with dynamic sizing headers/footers on iOS 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.10.3
+- Bugfix: Fix table section header/footer height calculation on iOS 10
+
 ## 1.10.2
 - Bugfix: Fix scrollview top pinning on iOS 11 and later where currently if the scrollview is in a navigation controller there is a gap between the scrollview top and the pinned view 
 

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.2</string>
+	<string>1.10.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -147,8 +147,16 @@ public final class TableKit<Section, Row> {
 
             view.sectionHeaderHeight = UITableView.automaticDimension
             view.sectionFooterHeight = UITableView.automaticDimension
-            view.estimatedSectionHeaderHeight = style.fixedHeaderHeight ?? UITableView.automaticDimension
-            view.estimatedSectionFooterHeight = style.fixedFooterHeight ?? UITableView.automaticDimension
+
+            if #available(iOS 11.0, *) {
+                view.estimatedSectionHeaderHeight = style.fixedHeaderHeight ?? UITableView.automaticDimension
+                view.estimatedSectionFooterHeight = style.fixedFooterHeight ?? UITableView.automaticDimension
+            } else {
+                // on iOS 10 estimated height need to be set to a positive value (the actual one doesn't seem to affect the result but might affect performance) for the size calculation to happen properly
+                // https://stackoverflow.com/a/50513288
+                view.estimatedSectionHeaderHeight = style.fixedHeaderHeight ?? 44
+                view.estimatedSectionFooterHeight = style.fixedFooterHeight ?? 44
+            }
 
             if view.autoResizingTableHeaderView === tableHeader {
                tableHeaderConstraint.constant = style.form.insets.top

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.10.2"
+  s.version      = "1.10.3"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.2</string>
+	<string>1.10.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
On iOS 10 estimated height need to be set to a positive value for the size calculation to happen properly. This is causing section headers/footers to not be rendered as it can be seen in the demo project:
![missing-headers](https://user-images.githubusercontent.com/1555713/63101908-58e79c80-bf7a-11e9-915a-4895a406d624.gif)

The height calculated by the tableview is wrong (~17) which doesn't respect the autolayout constraints of the provided view and its layout breaks.

See related questions and answers on SO like this one: https://stackoverflow.com/a/50513288

Expected (after the fix):
![Simulator Screen Shot - iPhone 7 - 2019-08-15 at 16 35 30](https://user-images.githubusercontent.com/1555713/63102087-b67be900-bf7a-11e9-8e9f-f7f1574674e8.png)