### PR TITLE
Fix typo "thinest" to "thinnest"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.10.4
 - Bugfix: Fix issue with ui refresh deadlock
+- Change: Deprecated `thinestLineWidth`, which has been renamed to `hairlineWidth`.
 
 ## 1.10.3
 - Bugfix: Fix table section header/footer height calculation on iOS 10

--- a/Form/SectionBackgroundStyle.swift
+++ b/Form/SectionBackgroundStyle.swift
@@ -38,9 +38,9 @@ public extension SectionBackgroundStyle {
 
 public extension SectionBackgroundStyle {
     static let none = SectionBackgroundStyle(background: .none, topSeparator: .none, bottomSeparator: .none)
-    static let system = SectionBackgroundStyle(background: BackgroundStyle(color: .white, border: BorderStyle(width: UIScreen.main.thinestLineWidth, color: .systemSeparator, cornerRadius: 0)),
+    static let system = SectionBackgroundStyle(background: BackgroundStyle(color: .white, border: BorderStyle(width: UIScreen.main.thinnestLineWidth, color: .systemSeparator, cornerRadius: 0)),
                                                topSeparator: .none,
-                                               bottomSeparator: InsettedStyle(style: SeparatorStyle(width: UIScreen.main.thinestLineWidth, color: .systemSeparator), insets: prototypeGroupedTableView.separatorInset))
+                                               bottomSeparator: InsettedStyle(style: SeparatorStyle(width: UIScreen.main.thinnestLineWidth, color: .systemSeparator), insets: prototypeGroupedTableView.separatorInset))
 
     static var systemSelected = SectionBackgroundStyle.system.restyled {
         $0.color = .systemSelection

--- a/Form/SectionBackgroundStyle.swift
+++ b/Form/SectionBackgroundStyle.swift
@@ -38,9 +38,9 @@ public extension SectionBackgroundStyle {
 
 public extension SectionBackgroundStyle {
     static let none = SectionBackgroundStyle(background: .none, topSeparator: .none, bottomSeparator: .none)
-    static let system = SectionBackgroundStyle(background: BackgroundStyle(color: .white, border: BorderStyle(width: UIScreen.main.thinnestLineWidth, color: .systemSeparator, cornerRadius: 0)),
+    static let system = SectionBackgroundStyle(background: BackgroundStyle(color: .white, border: BorderStyle(width: UIScreen.main.hairlineWidth, color: .systemSeparator, cornerRadius: 0)),
                                                topSeparator: .none,
-                                               bottomSeparator: InsettedStyle(style: SeparatorStyle(width: UIScreen.main.thinnestLineWidth, color: .systemSeparator), insets: prototypeGroupedTableView.separatorInset))
+                                               bottomSeparator: InsettedStyle(style: SeparatorStyle(width: UIScreen.main.hairlineWidth, color: .systemSeparator), insets: prototypeGroupedTableView.separatorInset))
 
     static var systemSelected = SectionBackgroundStyle.system.restyled {
         $0.color = .systemSelection

--- a/Form/SeparatorStyle.swift
+++ b/Form/SeparatorStyle.swift
@@ -61,12 +61,22 @@ public extension UIScreen {
     var thinnestLineWidth: CGFloat {
         return 1.0 / scale
     }
+
+    @available(*, deprecated, renamed: "thinnestLineWidth")
+    var thinestLineWidth: CGFloat {
+        return thinnestLineWidth
+    }
 }
 
 public extension UITraitCollection {
     /// Returns the thinnest line representable on the current used trait's screen, or the main screen in `self`'s displayScale is not defined.
     var thinnestLineWidth: CGFloat {
         return displayScale > 0 ? 1.0 / displayScale : UIScreen.main.thinnestLineWidth
+    }
+
+    @available(*, deprecated, renamed: "thinnestLineWidth")
+    var thinestLineWidth: CGFloat {
+        return thinnestLineWidth
     }
 
     /// Returns true if userInterfaceIdiom is pad
@@ -80,5 +90,10 @@ public extension CGFloat {
     /// Returns the thinnest line representable by the main screen
     static var thinnestLineWidth: CGFloat {
         return UIScreen.main.thinnestLineWidth
+    }
+
+    @available(*, deprecated, renamed: "thinnestLineWidth")
+    static var thinestLineWidth: CGFloat {
+        return thinnestLineWidth
     }
 }

--- a/Form/SeparatorStyle.swift
+++ b/Form/SeparatorStyle.swift
@@ -57,26 +57,26 @@ public extension Sequence where Iterator.Element == UIView {
 }
 
 public extension UIScreen {
-    /// Returns the thinnest line representable on `self`
-    var thinnestLineWidth: CGFloat {
+    /// Returns the thinnest line representable on `self`.
+    var hairlineWidth: CGFloat {
         return 1.0 / scale
     }
 
-    @available(*, deprecated, renamed: "thinnestLineWidth")
+    @available(*, deprecated, renamed: "hairlineWidth")
     var thinestLineWidth: CGFloat {
-        return thinnestLineWidth
+        return hairlineWidth
     }
 }
 
 public extension UITraitCollection {
     /// Returns the thinnest line representable on the current used trait's screen, or the main screen in `self`'s displayScale is not defined.
-    var thinnestLineWidth: CGFloat {
-        return displayScale > 0 ? 1.0 / displayScale : UIScreen.main.thinnestLineWidth
+    var hairlineWidth: CGFloat {
+        return displayScale > 0 ? 1.0 / displayScale : UIScreen.main.hairlineWidth
     }
 
-    @available(*, deprecated, renamed: "thinnestLineWidth")
+    @available(*, deprecated, renamed: "hairlineWidth")
     var thinestLineWidth: CGFloat {
-        return thinnestLineWidth
+        return hairlineWidth
     }
 
     /// Returns true if userInterfaceIdiom is pad
@@ -87,13 +87,13 @@ public extension UITraitCollection {
 }
 
 public extension CGFloat {
-    /// Returns the thinnest line representable by the main screen
-    static var thinnestLineWidth: CGFloat {
-        return UIScreen.main.thinnestLineWidth
+    /// Returns the thinnest line representable by the main screen.
+    static var hairlineWidth: CGFloat {
+        return UIScreen.main.hairlineWidth
     }
 
-    @available(*, deprecated, renamed: "thinnestLineWidth")
+    @available(*, deprecated, renamed: "hairlineWidth")
     static var thinestLineWidth: CGFloat {
-        return thinnestLineWidth
+        return hairlineWidth
     }
 }

--- a/Form/SeparatorStyle.swift
+++ b/Form/SeparatorStyle.swift
@@ -57,16 +57,16 @@ public extension Sequence where Iterator.Element == UIView {
 }
 
 public extension UIScreen {
-    /// Returns the thinest line representable on `self`
-    var thinestLineWidth: CGFloat {
+    /// Returns the thinnest line representable on `self`
+    var thinnestLineWidth: CGFloat {
         return 1.0 / scale
     }
 }
 
 public extension UITraitCollection {
-    /// Returns the thinest line representable on the current used trait's screen, or the main screen in `self`'s displayScale is not defined.
-    var thinestLineWidth: CGFloat {
-        return displayScale > 0 ? 1.0 / displayScale : UIScreen.main.thinestLineWidth
+    /// Returns the thinnest line representable on the current used trait's screen, or the main screen in `self`'s displayScale is not defined.
+    var thinnestLineWidth: CGFloat {
+        return displayScale > 0 ? 1.0 / displayScale : UIScreen.main.thinnestLineWidth
     }
 
     /// Returns true if userInterfaceIdiom is pad
@@ -77,8 +77,8 @@ public extension UITraitCollection {
 }
 
 public extension CGFloat {
-    /// Returns the thinest line representable by the main screen
-    static var thinestLineWidth: CGFloat {
-        return UIScreen.main.thinestLineWidth
+    /// Returns the thinnest line representable by the main screen
+    static var thinnestLineWidth: CGFloat {
+        return UIScreen.main.thinnestLineWidth
     }
 }

--- a/Form/UIImage+Styling.swift
+++ b/Form/UIImage+Styling.swift
@@ -64,8 +64,8 @@ extension UIImage {
         let ceiledTopSeparatorHeight = ceil(topSeparatorHeight)
 
         // Computing the smallest rect possible to draw this image - note that it should be slightly bigger than the border widths so that it draws a stretchable non-solid area too
-        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + 2 * .thinestLineWidth + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
-        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + 2 * .thinestLineWidth + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
+        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + 2 * .thinnestLineWidth + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
+        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + 2 * .thinnestLineWidth + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
         let rect = CGRect(x: 0, y: 0, width: max(1, rectWidth), height: max(1, rectHeight))
 
         let isOpaque: Bool

--- a/Form/UIImage+Styling.swift
+++ b/Form/UIImage+Styling.swift
@@ -64,8 +64,8 @@ extension UIImage {
         let ceiledTopSeparatorHeight = ceil(topSeparatorHeight)
 
         // Computing the smallest rect possible to draw this image - note that it should be slightly bigger than the border widths so that it draws a stretchable non-solid area too
-        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + 2 * .thinnestLineWidth + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
-        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + 2 * .thinnestLineWidth + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
+        let rectWidth = cornerRadius * 2 + ceiledBorderWidths.left + 2 * .hairlineWidth + ceiledBorderWidths.right + max(bottomSeparatorInsets.left, topSeparatorInsets.left) + max(bottomSeparatorInsets.right, topSeparatorInsets.right)
+        let rectHeight = cornerRadius * 2 + ceiledBorderWidths.top + 2 * .hairlineWidth + ceiledBorderWidths.bottom + ceiledSeparatorHeight + ceiledTopSeparatorHeight
         let rect = CGRect(x: 0, y: 0, width: max(1, rectWidth), height: max(1, rectHeight))
 
         let isOpaque: Bool


### PR DESCRIPTION
A very nit-picky thing in the API that has been bugging me for a while... Sorry!

I realize that this is a breaking change, but I don't think it's worth deprecating it if it's just a typo fix–especially with our user volume.

Please let me know if you have any objections to this!