### PR TITLE
Rename tablekit init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.5
+- Addition: Add new initializers for TableKit and CollectionKit that have an explicit `holdIn` parameter to keep subscriptions.
+- Change: Change the deprecation warning of TableKit and CollectionKit initializers to point to the new ones
+
 ## 1.10.4
 - Bugfix: Fix issue with ui refresh deadlock
 - Change: Deprecated `thinestLineWidth`, which has been renamed to `hairlineWidth`.

--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		3156BAED2139366B00ECC2EC /* MixedReusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3156BAEC2139366B00ECC2EC /* MixedReusable.swift */; };
 		5B4ABD3A2257365C0073FACE /* TableKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4ABD392257365C0073FACE /* TableKitTests.swift */; };
 		721954D821A44E450090F9E3 /* MinimumSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721954D721A44E450090F9E3 /* MinimumSize.swift */; };
+		722EB65023266A99003AA360 /* CollectionKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722EB64F23266A99003AA360 /* CollectionKitTests.swift */; };
 		724EC30D2241513D001F3E11 /* UILabel+StylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */; };
 		7270AFB0201FAB7C004DAAA3 /* ViewLayoutArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */; };
 		72C5ED6F226F432600E32125 /* UIScrollView+PinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */; };
@@ -139,6 +140,7 @@
 		3156BAEC2139366B00ECC2EC /* MixedReusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MixedReusable.swift; path = Form/MixedReusable.swift; sourceTree = "<group>"; };
 		5B4ABD392257365C0073FACE /* TableKitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableKitTests.swift; sourceTree = "<group>"; };
 		721954D721A44E450090F9E3 /* MinimumSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MinimumSize.swift; path = Form/MinimumSize.swift; sourceTree = "<group>"; };
+		722EB64F23266A99003AA360 /* CollectionKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionKitTests.swift; sourceTree = "<group>"; };
 		724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+StylingTests.swift"; sourceTree = "<group>"; };
 		7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewLayoutArea.swift; path = Form/ViewLayoutArea.swift; sourceTree = "<group>"; };
 		72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+PinningTests.swift"; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				1C2881821F20EE2000666A21 /* SelectViewTests.swift */,
 				1CDD56A91D9C10D7004B0CA9 /* TableTests.swift */,
 				5B4ABD392257365C0073FACE /* TableKitTests.swift */,
+				722EB64F23266A99003AA360 /* CollectionKitTests.swift */,
 				21367C6A1DACDF990021C98F /* TableChangeTests.swift */,
 				B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */,
 				F604260920B6A47E00BC4CAB /* ParentChildRelationalTests.swift */,
@@ -591,6 +594,7 @@
 				5B4ABD3A2257365C0073FACE /* TableKitTests.swift in Sources */,
 				CDD2A5211F42DE7500E2B78B /* HighlightedTests.swift in Sources */,
 				B35F8B4C1F3783E400904E37 /* CollectionDiffTests.swift in Sources */,
+				722EB65023266A99003AA360 /* CollectionKitTests.swift in Sources */,
 				72C5ED6F226F432600E32125 /* UIScrollView+PinningTests.swift in Sources */,
 				21367C6B1DACDF990021C98F /* TableChangeTests.swift in Sources */,
 				1C2881831F20EE2000666A21 /* SelectViewTests.swift in Sources */,

--- a/Form/CollectionKit.swift
+++ b/Form/CollectionKit.swift
@@ -39,12 +39,12 @@ public final class CollectionKit<Section, Row> {
     /// - Parameters:
     ///   - table: The data model managed by the kit. Defaults to an empty table.
     ///   - layout: The collection view layout to be used.
-    ///   - bag: Optional bag to hold the subscriptions to the collection view. Will retain self if supplied.
+    ///   - externalBag: Optional bag to hold the subscriptions to the collection view. Will retain `self` anf be retained by `self` if supplied so you need to dispose it explicitly to break the retain cycle.
     ///   - cellForRow: A block that creates a cell for a given index path.
-    public init(table: Table = Table(), layout: UICollectionViewLayout, holdIn bag: DisposeBag?, cellForRow: @escaping (UICollectionView, Row, TableIndex) -> UICollectionViewCell) {
+    public init(table: Table = Table(), layout: UICollectionViewLayout, holdIn externalBag: DisposeBag?, cellForRow: @escaping (UICollectionView, Row, TableIndex) -> UICollectionViewCell) {
         self.view = UICollectionView.defaultCollection(withLayout: layout)
-        self.bag = bag ?? DisposeBag()
-        bag?.hold(self)
+        self.bag = externalBag ?? DisposeBag()
+        externalBag?.hold(self)
 
         dataSource.table = table
         delegate.table = table

--- a/Form/CollectionKit.swift
+++ b/Form/CollectionKit.swift
@@ -36,19 +36,15 @@ public final class CollectionKit<Section, Row> {
         }
     }
 
-    /// Creates a new instance
     /// - Parameters:
-    ///   - table: The initial table. Defaults to an empty table.
-    private init(table: Table = Table(), layout: UICollectionViewLayout, deprecatedBag: DisposeBag?, cellForRow: @escaping (UICollectionView, Row, TableIndex) -> UICollectionViewCell) {
+    ///   - table: The data model managed by the kit. Defaults to an empty table.
+    ///   - layout: The collection view layout to be used.
+    ///   - bag: Optional bag to hold the subscriptions to the collection view. Will retain self if supplied.
+    ///   - cellForRow: A block that creates a cell for a given index path.
+    public init(table: Table = Table(), layout: UICollectionViewLayout, holdIn bag: DisposeBag?, cellForRow: @escaping (UICollectionView, Row, TableIndex) -> UICollectionViewCell) {
         self.view = UICollectionView.defaultCollection(withLayout: layout)
-
-        // Remove deprecatedBag parameter once deprecetated inits have been removed.
-        if let deprecatedBag = deprecatedBag {
-            bag = deprecatedBag
-            deprecatedBag.hold(self) // Hold on to self to simulate deprecated behaviour
-        } else {
-            bag = DisposeBag()
-        }
+        self.bag = bag ?? DisposeBag()
+        bag?.hold(self)
 
         dataSource.table = table
         delegate.table = table
@@ -89,12 +85,12 @@ public extension CollectionKit {
     /// - Parameters:
     ///   - table: The initial table. Defaults to an empty table.
     convenience init(table: Table = Table(), layout: UICollectionViewLayout, cellForRow: @escaping (UICollectionView, Row, TableIndex) -> UICollectionViewCell) {
-        self.init(table: table, layout: layout, deprecatedBag: nil, cellForRow: cellForRow)
+        self.init(table: table, layout: layout, holdIn: nil, cellForRow: cellForRow)
     }
 
-    @available(*, deprecated, message: "use `init(table:layout:cellForRow:)` instead")
+    @available(*, deprecated, message: "use `init(table:layout:holdIn:cellForRow:)` instead")
     convenience init(table: Table = Table(), layout: UICollectionViewLayout, bag: DisposeBag, cellForRow: @escaping (UICollectionView, Row, TableIndex) -> UICollectionViewCell) {
-        self.init(table: table, layout: layout, deprecatedBag: bag, cellForRow: cellForRow)
+        self.init(table: table, layout: layout, holdIn: bag, cellForRow: cellForRow)
     }
 }
 
@@ -110,7 +106,7 @@ public extension CollectionKit where Row: Reusable, Row.ReuseType: ViewRepresent
 
     @available(*, deprecated, message: "use `init(table:layout:)` instead")
     convenience init(table: Table = Table(), layout: UICollectionViewLayout, bag: DisposeBag) {
-        self.init(table: table, layout: layout, deprecatedBag: bag) { collection, cell, index in
+        self.init(table: table, layout: layout, holdIn: bag) { collection, cell, index in
             return collection.dequeueCell(forItem: cell, at: IndexPath(row: index.row, section: index.section))
         }
     }

--- a/Form/CollectionKit.swift
+++ b/Form/CollectionKit.swift
@@ -116,9 +116,13 @@ public extension CollectionKit where Row: Reusable, Row.ReuseType: ViewRepresent
         }
     }
 
-    @available(*, deprecated, message: "use `init(table:layout:)` instead")
+    @available(*, deprecated, message: "use `init(table:layout:holdIn:)` instead")
     convenience init(table: Table = Table(), layout: UICollectionViewLayout, bag: DisposeBag) {
-        self.init(table: table, layout: layout, holdIn: bag) { collection, cell, index in
+        self.init(table: table, layout: layout, holdIn: bag)
+    }
+
+    convenience init(table: Table = Table(), layout: UICollectionViewLayout, holdIn externalBag: DisposeBag) {
+        self.init(table: table, layout: layout, holdIn: externalBag) { collection, cell, index in
             return collection.dequeueCell(forItem: cell, at: IndexPath(row: index.row, section: index.section))
         }
     }

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>1.10.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -272,10 +272,6 @@ public extension TableKit {
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, bag: DisposeBag, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
         self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: headerForSection, footerForSection: footerForSection, cellForRow: cellForRow)
     }
-
-    convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, holdIn bag: DisposeBag, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
-        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: headerForSection, footerForSection: footerForSection, cellForRow: cellForRow)
-    }
 }
 
 public extension TableKit where Row: Reusable, Row.ReuseType: ViewRepresentable {

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -105,17 +105,17 @@ public final class TableKit<Section, Row> {
     ///   - table: The data model managed by the kit. Defaults to an empty table.
     ///   - style: The style to be applied to the managed table view.
     ///   - view: Optional table view to be used instead of the default one. See `DefaultStyling`.
-    ///   - bag: Optional bag to hold the subscriptions to the collection view. Will retain self if supplied.
+    ///   - externalBag: Optional bag to hold the subscriptions to the collection view. Will retain `self` anf be retained by `self` if supplied so you need to dispose it explicitly to break the retain cycle.
     ///   - headerForSection: Optional block that creates a header view for a given section. Can be configured afterwards through the delegate too.
     ///   - footerForSection: Optional block that creates a footer view for a given section. Can be configured afterwards through the delegate too.
     ///   - cellForRow: A block that creates a cell for a given index path.
-    public init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, holdIn bag: DisposeBag?, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
+    public init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, holdIn externalBag: DisposeBag?, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
         let view = view ?? UITableView.defaultTable(for: style.tableStyle)
         self.view = view
         self.style = style
 
-        self.bag = bag ?? DisposeBag()
-        bag?.hold(self)
+        self.bag = externalBag ?? DisposeBag()
+        externalBag?.hold(self)
 
         dataSource.table = table
         delegate.table = table

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -101,18 +101,21 @@ public final class TableKit<Section, Row> {
         }
     }
 
-    private init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, deprecatedBag: DisposeBag?, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
+    /// - Parameters:
+    ///   - table: The data model managed by the kit. Defaults to an empty table.
+    ///   - style: The style to be applied to the managed table view.
+    ///   - view: Optional table view to be used instead of the default one. See `DefaultStyling`.
+    ///   - bag: Optional bag to hold the subscriptions to the collection view. Will retain self if supplied.
+    ///   - headerForSection: Optional block that creates a header view for a given section. Can be configured afterwards through the delegate too.
+    ///   - footerForSection: Optional block that creates a footer view for a given section. Can be configured afterwards through the delegate too.
+    ///   - cellForRow: A block that creates a cell for a given index path.
+    public init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, holdIn bag: DisposeBag?, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
         let view = view ?? UITableView.defaultTable(for: style.tableStyle)
         self.view = view
         self.style = style
 
-        // Remove deprecatedBag parameter once deprecetated inits have been removed.
-        if let deprecatedBag = deprecatedBag {
-            bag = deprecatedBag
-            deprecatedBag.hold(self) // Hold on to self to simulate deprecated behaviour
-        } else {
-            bag = DisposeBag()
-        }
+        self.bag = bag ?? DisposeBag()
+        bag?.hold(self)
 
         dataSource.table = table
         delegate.table = table
@@ -262,12 +265,16 @@ public extension TableKit {
     /// - Parameters:
     ///   - table: The initial table. Defaults to an empty table.
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
-        self.init(table: table, style: style, view: view, deprecatedBag: nil, headerForSection: headerForSection, footerForSection: footerForSection, cellForRow: cellForRow)
+        self.init(table: table, style: style, view: view, holdIn: nil, headerForSection: headerForSection, footerForSection: footerForSection, cellForRow: cellForRow)
     }
 
-    @available(*, deprecated, message: "use `init(table:style:view:headerForSection:footerForSection:cellForRow:)` instead")
+    @available(*, deprecated, message: "use `init(table:style:view:holdIn:headerForSection:footerForSection:cellForRow:)` instead")
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, bag: DisposeBag, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
-        self.init(table: table, style: style, view: view, deprecatedBag: bag, headerForSection: headerForSection, footerForSection: footerForSection, cellForRow: cellForRow)
+        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: headerForSection, footerForSection: footerForSection, cellForRow: cellForRow)
+    }
+
+    convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, holdIn bag: DisposeBag, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil, cellForRow: @escaping (UITableView, Row) -> UITableViewCell) {
+        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: headerForSection, footerForSection: footerForSection, cellForRow: cellForRow)
     }
 }
 
@@ -283,7 +290,7 @@ public extension TableKit where Row: Reusable, Row.ReuseType: ViewRepresentable 
 
     @available(*, deprecated, message: "use `init(table:style:view:headerForSection:footerForSection:)` instead")
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, bag: DisposeBag, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil) {
-        self.init(table: table, style: style, view: view, deprecatedBag: bag, headerForSection: headerForSection, footerForSection: footerForSection) { table, row in
+        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: headerForSection, footerForSection: footerForSection) { table, row in
             table.dequeueCell(forItem: row, style: style)
         }
     }
@@ -303,7 +310,7 @@ public extension TableKit where Row: Reusable, Row.ReuseType: ViewRepresentable,
 
     @available(*, deprecated, message: "use `init(table:style:view:footerForSection:)` instead")
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, bag: DisposeBag, footerForSection: ((UITableView, Section) -> UIView?)? = nil) {
-        self.init(table: table, style: style, view: view, deprecatedBag: bag, headerForSection: { table, section in
+        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: { table, section in
             table.dequeueHeaderFooterView(forItem: section, style: style.header, formStyle: style.form)
         }, footerForSection: footerForSection, cellForRow: { table, row in
             table.dequeueCell(forItem: row, style: style)
@@ -327,7 +334,7 @@ public extension TableKit where Row: Reusable, Row.ReuseType: ViewRepresentable,
 
     @available(*, deprecated, message: "use `init(table:style:view)` instead")
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, bag: DisposeBag) {
-        self.init(table: table, style: style, view: view, deprecatedBag: bag, headerForSection: { table, section in
+        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: { table, section in
             table.dequeueHeaderFooterView(forItem: section.header, style: style.header, formStyle: style.form, reuseIdentifier: "header")
         }, footerForSection: { table, section in
             table.dequeueHeaderFooterView(forItem: section.footer, style: style.footer, formStyle: style.form, reuseIdentifier: "footer")

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -173,7 +173,7 @@ public final class TableKit<Section, Row> {
             }
 
             if view.autoResizingTableHeaderView === tableHeader {
-               tableHeaderConstraint.constant = style.form.insets.top
+                tableHeaderConstraint.constant = style.form.insets.top
             }
 
             if view.autoResizingTableFooterView === tableFooter {
@@ -295,9 +295,13 @@ public extension TableKit where Row: Reusable, Row.ReuseType: ViewRepresentable 
         }
     }
 
-    @available(*, deprecated, message: "use `init(table:style:view:headerForSection:footerForSection:)` instead")
+    @available(*, deprecated, message: "use `init(table:style:view:holdIn:headerForSection:footerForSection:)` instead")
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, bag: DisposeBag, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil) {
-        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: headerForSection, footerForSection: footerForSection) { table, row in
+        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: headerForSection, footerForSection: footerForSection)
+    }
+
+    convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, holdIn externalBag: DisposeBag, headerForSection: ((UITableView, Section) -> UIView?)? = nil, footerForSection: ((UITableView, Section) -> UIView?)? = nil) {
+        self.init(table: table, style: style, view: view, holdIn: externalBag, headerForSection: headerForSection, footerForSection: footerForSection) { table, row in
             table.dequeueCell(forItem: row, style: style)
         }
     }
@@ -315,9 +319,13 @@ public extension TableKit where Row: Reusable, Row.ReuseType: ViewRepresentable,
         })
     }
 
-    @available(*, deprecated, message: "use `init(table:style:view:footerForSection:)` instead")
+    @available(*, deprecated, message: "use `init(table:style:view:holdIn:footerForSection:)` instead")
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, bag: DisposeBag, footerForSection: ((UITableView, Section) -> UIView?)? = nil) {
-        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: { table, section in
+        self.init(table: table, style: style, view: view, holdIn: bag, footerForSection: footerForSection)
+    }
+
+    convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, holdIn externalBag: DisposeBag, footerForSection: ((UITableView, Section) -> UIView?)? = nil) {
+        self.init(table: table, style: style, view: view, holdIn: externalBag, headerForSection: { table, section in
             table.dequeueHeaderFooterView(forItem: section, style: style.header, formStyle: style.form)
         }, footerForSection: footerForSection, cellForRow: { table, row in
             table.dequeueCell(forItem: row, style: style)
@@ -339,9 +347,13 @@ public extension TableKit where Row: Reusable, Row.ReuseType: ViewRepresentable,
         })
     }
 
-    @available(*, deprecated, message: "use `init(table:style:view)` instead")
+    @available(*, deprecated, message: "use `init(table:style:view:holdIn)` instead")
     convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, bag: DisposeBag) {
-        self.init(table: table, style: style, view: view, holdIn: bag, headerForSection: { table, section in
+        self.init(table: table, style: style, view: view, holdIn: bag)
+    }
+
+    convenience init(table: Table = Table(), style: DynamicTableViewFormStyle = .default, view: UITableView? = nil, holdIn externalBag: DisposeBag) {
+        self.init(table: table, style: style, view: view, holdIn: externalBag, headerForSection: { table, section in
             table.dequeueHeaderFooterView(forItem: section.header, style: style.header, formStyle: style.form, reuseIdentifier: "header")
         }, footerForSection: { table, section in
             table.dequeueHeaderFooterView(forItem: section.footer, style: style.footer, formStyle: style.form, reuseIdentifier: "footer")

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.10.3"
+  s.version      = "1.10.5"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/CollectionKitTests.swift
+++ b/FormTests/CollectionKitTests.swift
@@ -1,0 +1,45 @@
+//
+// Copyright © 2019 iZettle. All rights reserved.
+//
+
+import XCTest
+import Flow
+@testable import Form
+
+class CollectionKitTests: XCTestCase {
+    func testCollectionKitSubscriptionsAreSet() {
+        let kit: CollectionKit! = CollectionKit(table: Table(rows: [1, 2]), layout: UICollectionViewFlowLayout()) { _, _, _ in UICollectionViewCell() }
+        XCTAssertTrue(kit.dataSource.cellForIndex.isSet)
+    }
+
+    func testCollectionKitSubscriptionsAreSet_externalBag() {
+        let bag = DisposeBag()
+        let kit: TableKit! = TableKit(table: Table(rows: [1, 2]), holdIn: bag) { _, _ in UITableViewCell() }
+        XCTAssertTrue(kit.dataSource.cellForIndex.isSet)
+
+        bag.dispose()
+
+        XCTAssertFalse(kit.dataSource.cellForIndex.isSet)
+    }
+
+    func testCollectionKitNoRetainCycles() {
+        var kit: CollectionKit! = CollectionKit(table: Table(rows: [1, 2]), layout: UICollectionViewFlowLayout()) { _, _, _ in UICollectionViewCell() }
+        weak var weakKit = kit
+        XCTAssertNotNil(weakKit)
+        kit = nil
+        XCTAssertNil(weakKit)
+    }
+
+    func testCollectionKitNoRetainCyclesWithBag() {
+        var bag: DisposeBag! = DisposeBag()
+        weak var weakBag = bag
+
+        var kit: CollectionKit! = CollectionKit(table: Table(rows: [1, 2]), layout: UICollectionViewFlowLayout(), holdIn: weakBag) { _, _, _ in UICollectionViewCell() }
+        weak var weakKit = kit
+        XCTAssertNotNil(weakKit)
+        bag = nil
+        kit = nil
+        XCTAssertNil(weakKit)
+        XCTAssertNil(bag)
+    }
+}

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.3</string>
+	<string>1.10.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormTests/TableKitTests.swift
+++ b/FormTests/TableKitTests.swift
@@ -55,6 +55,27 @@ class TableKitTests: XCTestCase {
         XCTAssertNil(oldEmptyStateView.superview)
     }
 
+    func testTableKitSubscriptionsAreSet() {
+        let kit: TableKit! = TableKit(table: Table(rows: [1, 2]), holdIn: nil) { _, _ in UITableViewCell() }
+        XCTAssertTrue(kit.dataSource.cellForIndex.isSet)
+        XCTAssertTrue(kit.delegate.viewForHeaderInSection.isSet)
+        XCTAssertTrue(kit.delegate.viewForFooterInSection.isSet)
+    }
+
+    func testTableKitSubscriptionsAreSet_externalBag() {
+        let bag = DisposeBag()
+        let kit: TableKit! = TableKit(table: Table(rows: [1, 2]), holdIn: bag) { _, _ in UITableViewCell() }
+        XCTAssertTrue(kit.dataSource.cellForIndex.isSet)
+        XCTAssertTrue(kit.delegate.viewForHeaderInSection.isSet)
+        XCTAssertTrue(kit.delegate.viewForFooterInSection.isSet)
+
+        bag.dispose()
+
+        XCTAssertFalse(kit.dataSource.cellForIndex.isSet)
+        XCTAssertFalse(kit.delegate.viewForHeaderInSection.isSet)
+        XCTAssertFalse(kit.delegate.viewForFooterInSection.isSet)
+    }
+
     func testTableKitNoRetainCycles() {
         var kit: TableKit! = TableKit(table: Table(rows: [1, 2])) { _, _ in UITableViewCell() }
         weak var weakKit = kit
@@ -70,29 +91,6 @@ class TableKitTests: XCTestCase {
         var kit: TableKit! = TableKit(table: Table(rows: [1, 2]), holdIn: weakBag) { _, _ in UITableViewCell() }
         weak var weakKit = kit
         XCTAssertNotNil(weakKit)
-        bag.dispose()
-        bag = nil
-        kit = nil
-        XCTAssertNil(weakKit)
-        XCTAssertNil(bag)
-    }
-
-    func testCollectionKitNoRetainCycles() {
-        var kit: CollectionKit! = CollectionKit(table: Table(rows: [1, 2]), layout: UICollectionViewFlowLayout()) { _, _, _ in UICollectionViewCell() }
-        weak var weakKit = kit
-        XCTAssertNotNil(weakKit)
-        kit = nil
-        XCTAssertNil(weakKit)
-    }
-
-    func testCollectionKitNoRetainCyclesWithBag() {
-        var bag: DisposeBag! = DisposeBag()
-        weak var weakBag = bag
-
-        var kit: CollectionKit! = CollectionKit(table: Table(rows: [1, 2]), layout: UICollectionViewFlowLayout(), holdIn: weakBag) { _, _, _ in UICollectionViewCell() }
-        weak var weakKit = kit
-        XCTAssertNotNil(weakKit)
-        bag.dispose()
         bag = nil
         kit = nil
         XCTAssertNil(weakKit)

--- a/FormTests/TableKitTests.swift
+++ b/FormTests/TableKitTests.swift
@@ -63,11 +63,39 @@ class TableKitTests: XCTestCase {
         XCTAssertNil(weakKit)
     }
 
+    func testTableKitNoRetainCyclesWithBag() {
+        var bag: DisposeBag! = DisposeBag()
+        weak var weakBag = bag
+
+        var kit: TableKit! = TableKit(table: Table(rows: [1, 2]), holdIn: weakBag) { _, _ in UITableViewCell() }
+        weak var weakKit = kit
+        XCTAssertNotNil(weakKit)
+        bag.dispose()
+        bag = nil
+        kit = nil
+        XCTAssertNil(weakKit)
+        XCTAssertNil(bag)
+    }
+
     func testCollectionKitNoRetainCycles() {
         var kit: CollectionKit! = CollectionKit(table: Table(rows: [1, 2]), layout: UICollectionViewFlowLayout()) { _, _, _ in UICollectionViewCell() }
         weak var weakKit = kit
         XCTAssertNotNil(weakKit)
         kit = nil
         XCTAssertNil(weakKit)
+    }
+
+    func testCollectionKitNoRetainCyclesWithBag() {
+        var bag: DisposeBag! = DisposeBag()
+        weak var weakBag = bag
+
+        var kit: CollectionKit! = CollectionKit(table: Table(rows: [1, 2]), layout: UICollectionViewFlowLayout(), holdIn: weakBag) { _, _, _ in UICollectionViewCell() }
+        weak var weakKit = kit
+        XCTAssertNotNil(weakKit)
+        bag.dispose()
+        bag = nil
+        kit = nil
+        XCTAssertNil(weakKit)
+        XCTAssertNil(bag)
     }
 }


### PR DESCRIPTION
## What
- Addition: Add new initializers for TableKit and CollectionKit that have an explicit `holdIn` parameter to keep subscriptions.
- Change: Change the deprecation warning of TableKit and CollectionKit initializers to point to the new ones

## Why
In a previous release [we removed](https://github.com/iZettle/Form/pull/107) the `bag` parameter from the TableKit and CollectionKit initializers by deprecating the ones taking a `bag`. This deprecation has some side effects because before it was not required to retain the kit to retain its functionality so in some places additional `bag.hold(kit)` needed to be added (we also [discussed](https://iz-ios-oss.slack.com/archives/CC973V10V/p1564064059002600) this in [Slack](https://github.com/iZettle/Form#collaborate)). The iZettle team agrees that this is not very intuitive given that we have so many other initializers (including in Form) that take bag as a parameter if they need to store some internal behaviour. On the other hand, it makes sense that if you don't retain an object you will loose its behaviour. That's why we decided to keep both methods but make it a bit more explicit why is the bag passes. So now the parameter name is `holdIn` and we added docs.