### PR TITLE
Fix broken scroll-to-top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.10.5
+- Bugfix: Fixed scroll-to-top not working correctly.
+
 ## 1.10.4
 - Bugfix: Fix issue with ui refresh deadlock
 - Change: Deprecated `thinestLineWidth`, which has been renamed to `hairlineWidth`.

--- a/Form/ScrollViewDelegate.swift
+++ b/Form/ScrollViewDelegate.swift
@@ -75,7 +75,7 @@ public class ScrollViewDelegate: NSObject, UIScrollViewDelegate {
     }
 
     public func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
-        return shouldScrollToTop.call() ?? false
+        return shouldScrollToTop.call() ?? true
     }
 
     public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {


### PR DESCRIPTION
Scrollviews didn't scroll to top as they should by default.

Fallback value changed to true/YES, which is the Apple default, see [UIScrollViewDelegate Docs](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619378-scrollviewshouldscrolltotop)