### PR TITLE
Fix `reuseIdentifier` being wrongly used instead of `kind`

### DIFF
--- a/Form/UICollectionViewCell+Utilities.swift
+++ b/Form/UICollectionViewCell+Utilities.swift
@@ -90,7 +90,7 @@ public extension UICollectionView {
     /// - Returns: A supplementary view with the view embedded in.
     /// - Note: See `Reusable` for more info about reconfigure.
     func dequeueSupplementaryView<Item>(forItem item: Item, at indexPath: IndexPath, kind: String = String(describing: Item.self), reuseIdentifier: String = String(describing: Item.self), contentViewAndReconfigure: () -> (UIView, (Item?, Item) -> Disposable), _ noTrailingClosure: Void = ()) -> UICollectionReusableView {
-        register(UICollectionReusableView.self, forSupplementaryViewOfKind: reuseIdentifier, withReuseIdentifier: reuseIdentifier)
+        register(UICollectionReusableView.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: reuseIdentifier)
 
         let supplementaryView = dequeueSupplementaryView(withKind: kind, reuseIdentifier: reuseIdentifier, for: indexPath)
         supplementaryView.setItem(item, contentViewAndReconfigure: contentViewAndReconfigure)


### PR DESCRIPTION
Found this small little bug when I tried to do a header in a CollectionKit.

This crashed before the fix:

```swift
bag += collectionKit.dataSource.supplementaryElement(for: UICollectionView.elementKindSectionHeader).set { index -> UICollectionReusableView in
 let view = collectionKit.view.dequeueSupplementaryView(
   forItem: ImageLibraryButton(),
   kind: UICollectionView.elementKindSectionHeader,
   at: IndexPath(row: index.row, section: index.section)
 )
 return view
}
```

This has probably never been caught as https://github.com/iZettle/Form/blob/master/Form/CollectionKit.swift#L183 assumes that kind is `String(describing: Reusable.self)` which is not the case for headers and footers.