### PR TITLE
Import UIKit instead of Foundation

### DIFF
--- a/Form/DisplayableString.swift
+++ b/Form/DisplayableString.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Flow
 
 /// Conforming types can provide a custom `displayValue` for displaying to end-users.

--- a/Form/FieldStyle.swift
+++ b/Form/FieldStyle.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Flow
 
 public struct FieldStyle: Style {

--- a/Form/MinimumSize.swift
+++ b/Form/MinimumSize.swift
@@ -5,7 +5,7 @@
 //  Created by Nataliya Patsovska on 2018-11-20.
 //
 
-import Foundation
+import UIKit
 
 public struct MinimumSize: Style {
     public var width: CGFloat?

--- a/Form/MixedReusable.swift
+++ b/Form/MixedReusable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Flow
 
 /// Helper containter for creating e.g. `Table`s of mixed content.

--- a/Form/Reusable.swift
+++ b/Form/Reusable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Flow
 
 /// Conforming types defines how to make a `ReuseType` that can constructed once and configured many times,

--- a/Form/ScrollViewDelegate.swift
+++ b/Form/ScrollViewDelegate.swift
@@ -3,7 +3,7 @@
 // Copyright (c) 2018 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Flow
 
 public class ScrollViewDelegate: NSObject, UIScrollViewDelegate {

--- a/Form/SelectView.swift
+++ b/Form/SelectView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Flow
 
 public final class SelectView: UIView, Selectable, Highlightable {

--- a/Form/SubviewOrderable.swift
+++ b/Form/SubviewOrderable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Flow
 
 /// Conforming types provides a mutable ordering of views.

--- a/Form/TextStyle+Utilities.swift
+++ b/Form/TextStyle+Utilities.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 public extension TextStyle {
     /// Returns a restyled instance using `color`

--- a/Form/UITextField+Styling.swift
+++ b/Form/UITextField+Styling.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import Flow
 
 public extension UITextField {

--- a/Form/ValueEditor.swift
+++ b/Form/ValueEditor.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// A concrete implementation of a text editor using provided functions to implement `TextEditor`.
 public struct ValueEditor<Value>: TextEditor {

--- a/Form/ViewLayoutArea.swift
+++ b/Form/ViewLayoutArea.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 iZettle. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// A rectangular area in the coordinate system of a view that can be translated to a UILayoutGuide and participate in Auto Layout.
 public enum ViewLayoutArea {


### PR DESCRIPTION
We didn't have UIKit implicitly imported while using Swift Package Manager, so need to fix this before the PR with the SPM example project, so the example project can point to master (until we have done the release).