### PR TITLE
Bump the minimum required version of Presentation to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.0.0
 - Added: Support for Swift Package Manager
 - Change: Deprecate registerViewForSupplementaryElement and add a new one that works with UICollectionView headers and footers
+- Change: Bump the minimum required version of Presentation to 1.9.0
+- Added: New initializers for RowsSelection that works with the latest version of Presentation framework. The old one is deprecated.
 
 ## 1.10.5
 - Bugfix: Fixed scroll-to-top not working correctly.

--- a/Form/RowsSelection.swift
+++ b/Form/RowsSelection.swift
@@ -36,12 +36,17 @@ public struct RowsSelection<Row: SelectableRow> {
         return lazySelection.unbox
     }
 
+    @available(*, deprecated, message: "pass isCollapsed as a ReadSignal<Bool?> instead")
+    public init(isCollapsed: ReadSignal<Bool>, isInline: @escaping (Row) -> Bool = { _ in true }, bag: DisposeBag) {
+        self.init(isCollapsed: isCollapsed.map { value -> Bool? in return value }, isInline: isInline, bag: bag)
+    }
+
     /// Creates a new instance.
     /// - Parameters:
     ///   - isCollapsed: Whether or not details are displayed.
     ///   - isInline: Whether or not are row should will be displayed in details view or not.
     ///   - bag: A bag used to add row selection activities.
-    public init(isCollapsed: ReadSignal<Bool>, isInline: @escaping (Row) -> Bool = { _ in true }, bag: DisposeBag) {
+    public init(isCollapsed: ReadSignal<Bool?>, isInline: @escaping (Row) -> Bool = { _ in true }, bag: DisposeBag) {
         let visibleRows = signalAndRowsProperty.flatMapLatest { rows in
             Flow.combineLatest(rows.map { $0.1 }).map { $0.compactMap { $0 }.filter(isInline) }
         }

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Presentation' do |presentation|
-    presentation.dependency 'PresentationFramework', '~> 1.1'
+    presentation.dependency 'PresentationFramework', '~> 1.9.0'
   end
 
   s.source       = { :git => "https://github.com/iZettle/Form.git", :tag => "#{s.version}" }


### PR DESCRIPTION
The latest changes in Presentation framework deprecate a method that has been used in Form (of Presentation can be imported). I bumped the version in the podspec and deprecated the old RowSelection method so that projects that use both frameworks can avoid having deprecation warnings.