### PR TITLE
Bump version to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0
+## 2.0
 - Added: Support for Swift Package Manager
 - Change: Deprecate registerViewForSupplementaryElement and add a new one that works with UICollectionView headers and footers
 - Change: Bump the minimum required version of Presentation to 1.9.0

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.5</string>
+	<string>2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "1.10.5"
+  s.version      = "2.0"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.5</string>
+	<string>2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- Added: Support for Swift Package Manager
- Added: New initializers for RowsSelection that works with the latest version of Presentation framework. The old one is deprecated.
- Change: Bump the minimum required version of Presentation to 1.9.0
- Change: Removed deprecated functions, symbols etc.
- Change: Deprecate registerViewForSupplementaryElement and add a new one that works with UICollectionView headers and footers