### PR TITLE
Fix issue (#122) with`scrollToRevealFirstResponder`

### DIFF
--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		5B4ABD3A2257365C0073FACE /* TableKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4ABD392257365C0073FACE /* TableKitTests.swift */; };
 		721954D821A44E450090F9E3 /* MinimumSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721954D721A44E450090F9E3 /* MinimumSize.swift */; };
 		722EB65023266A99003AA360 /* CollectionKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722EB64F23266A99003AA360 /* CollectionKitTests.swift */; };
+		722EB63723242D37003AA360 /* ScrollViewVerticalContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722EB63623242D37003AA360 /* ScrollViewVerticalContextTests.swift */; };
 		724EC30D2241513D001F3E11 /* UILabel+StylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */; };
 		7270AFB0201FAB7C004DAAA3 /* ViewLayoutArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */; };
 		72C5ED6F226F432600E32125 /* UIScrollView+PinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */; };
@@ -136,6 +137,7 @@
 		5B4ABD392257365C0073FACE /* TableKitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableKitTests.swift; sourceTree = "<group>"; };
 		721954D721A44E450090F9E3 /* MinimumSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MinimumSize.swift; path = Form/MinimumSize.swift; sourceTree = "<group>"; };
 		722EB64F23266A99003AA360 /* CollectionKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionKitTests.swift; sourceTree = "<group>"; };
+		722EB63623242D37003AA360 /* ScrollViewVerticalContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewVerticalContextTests.swift; sourceTree = "<group>"; };
 		724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+StylingTests.swift"; sourceTree = "<group>"; };
 		7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewLayoutArea.swift; path = Form/ViewLayoutArea.swift; sourceTree = "<group>"; };
 		72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+PinningTests.swift"; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 				F6B81B9320CA906000B6AC39 /* NumberEditorTests.swift */,
 				724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */,
 				72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */,
+				722EB63623242D37003AA360 /* ScrollViewVerticalContextTests.swift */,
 				F62E45B81CABFB5300C6867E /* Info.plist */,
 			);
 			path = FormTests;
@@ -578,6 +581,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				722EB63723242D37003AA360 /* ScrollViewVerticalContextTests.swift in Sources */,
 				CFD2FFE3221323BF002D4D36 /* TextStyleTests.swift in Sources */,
 				F604260A20B6A47E00BC4CAB /* ParentChildRelationalTests.swift in Sources */,
 				F6B81B9420CA906000B6AC39 /* NumberEditorTests.swift in Sources */,

--- a/FormTests/ScrollViewVerticalContextTests.swift
+++ b/FormTests/ScrollViewVerticalContextTests.swift
@@ -1,0 +1,67 @@
+//
+//  UIScrollView+KeyboardTests.swift
+//  FormTests
+//
+//  Created by Nataliya Patsovska on 2019-09-07.
+//  Copyright © 2019 iZettle. All rights reserved.
+//
+
+import XCTest
+@testable import Form
+import Flow
+
+class ScrollViewVerticalContextTests: XCTestCase {
+    func testFocusPosition_noOffsetContext() {
+        let verticalContext = ScrollViewVerticalContext(
+            visibleRectHeight: 100,
+            visibleRectOffsetY: 0,
+            visibleRectInsetTop: 0,
+            visibleRectInsetBottom: 0
+        )
+
+        // whitin the visible area
+        XCTAssertNil(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 0, width: 100, height: 50)))
+        XCTAssertNil(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 50, width: 100, height: 50)))
+
+        // below the visible area
+        XCTAssertEqual(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 51, width: 100, height: 50)), 101)
+    }
+
+    func testFocusPosition_yOffsetContext() {
+        let verticalContext = ScrollViewVerticalContext(
+            visibleRectHeight: 100,
+            visibleRectOffsetY: 50,
+            visibleRectInsetTop: 0,
+            visibleRectInsetBottom: 0
+        )
+
+        // whitin the visible area
+        XCTAssertNil(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 50, width: 100, height: 50)))
+        XCTAssertNil(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 100, width: 100, height: 50)))
+
+        // above the visible area
+        XCTAssertEqual(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 49, width: 100, height: 50)), 49)
+
+        // below the visible area
+        XCTAssertEqual(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 101, width: 100, height: 50)), 151)
+    }
+
+    func testFocusPosition_insettedContext() {
+        let verticalContext = ScrollViewVerticalContext(
+            visibleRectHeight: 100,
+            visibleRectOffsetY: 50,
+            visibleRectInsetTop: -10,
+            visibleRectInsetBottom: 20
+        )
+
+        // whitin the visible area
+        XCTAssertNil(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 60, width: 100, height: 50)))
+        XCTAssertNil(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 90, width: 100, height: 50)))
+
+        // above the visible area
+        XCTAssertEqual(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 59, width: 100, height: 50)), 59)
+
+        // below the visible area
+        XCTAssertEqual(verticalContext.targetFocusPosition(for: CGRect(x: 0, y: 91, width: 100, height: 50)), 141)
+    }
+}


### PR DESCRIPTION
https://github.com/iZettle/Form/issues/122

I was struggling to understand why this issue is happening (probably something around the usage of frame vs bounds).. We were getting weird negative offset in few cases causing glitches when switching between fields. We ended up re-writing some of the logic together with @enhorn . Now we're comparing only the vertical positions taking into account scroll view offset and insets. 

Will run couple of more manual tests on devices but so far everything looks good. Let me know what do you think.