### PR TITLE
Fixed binding of MasterDetailSelection to TableKit

### DIFF
--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -28,8 +28,9 @@
 		3156BAED2139366B00ECC2EC /* MixedReusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3156BAEC2139366B00ECC2EC /* MixedReusable.swift */; };
 		5B4ABD3A2257365C0073FACE /* TableKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4ABD392257365C0073FACE /* TableKitTests.swift */; };
 		721954D821A44E450090F9E3 /* MinimumSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721954D721A44E450090F9E3 /* MinimumSize.swift */; };
-		722EB65023266A99003AA360 /* CollectionKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722EB64F23266A99003AA360 /* CollectionKitTests.swift */; };
+		7222DD03235A34310036619F /* TableKit+MasterSelectionBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7222DD02235A34310036619F /* TableKit+MasterSelectionBindingTests.swift */; };
 		722EB63723242D37003AA360 /* ScrollViewVerticalContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722EB63623242D37003AA360 /* ScrollViewVerticalContextTests.swift */; };
+		722EB65023266A99003AA360 /* CollectionKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722EB64F23266A99003AA360 /* CollectionKitTests.swift */; };
 		724EC30D2241513D001F3E11 /* UILabel+StylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */; };
 		7270AFB0201FAB7C004DAAA3 /* ViewLayoutArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */; };
 		72C5ED6F226F432600E32125 /* UIScrollView+PinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */; };
@@ -136,8 +137,9 @@
 		3156BAEC2139366B00ECC2EC /* MixedReusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MixedReusable.swift; path = Form/MixedReusable.swift; sourceTree = "<group>"; };
 		5B4ABD392257365C0073FACE /* TableKitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableKitTests.swift; sourceTree = "<group>"; };
 		721954D721A44E450090F9E3 /* MinimumSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MinimumSize.swift; path = Form/MinimumSize.swift; sourceTree = "<group>"; };
-		722EB64F23266A99003AA360 /* CollectionKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionKitTests.swift; sourceTree = "<group>"; };
+		7222DD02235A34310036619F /* TableKit+MasterSelectionBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableKit+MasterSelectionBindingTests.swift"; sourceTree = "<group>"; };
 		722EB63623242D37003AA360 /* ScrollViewVerticalContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewVerticalContextTests.swift; sourceTree = "<group>"; };
+		722EB64F23266A99003AA360 /* CollectionKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionKitTests.swift; sourceTree = "<group>"; };
 		724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+StylingTests.swift"; sourceTree = "<group>"; };
 		7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewLayoutArea.swift; path = Form/ViewLayoutArea.swift; sourceTree = "<group>"; };
 		72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+PinningTests.swift"; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 				1C2881821F20EE2000666A21 /* SelectViewTests.swift */,
 				1CDD56A91D9C10D7004B0CA9 /* TableTests.swift */,
 				5B4ABD392257365C0073FACE /* TableKitTests.swift */,
+				7222DD02235A34310036619F /* TableKit+MasterSelectionBindingTests.swift */,
 				722EB64F23266A99003AA360 /* CollectionKitTests.swift */,
 				21367C6A1DACDF990021C98F /* TableChangeTests.swift */,
 				B35F8B4B1F3783E400904E37 /* CollectionDiffTests.swift */,
@@ -585,6 +588,7 @@
 				CFD2FFE3221323BF002D4D36 /* TextStyleTests.swift in Sources */,
 				F604260A20B6A47E00BC4CAB /* ParentChildRelationalTests.swift in Sources */,
 				F6B81B9420CA906000B6AC39 /* NumberEditorTests.swift in Sources */,
+				7222DD03235A34310036619F /* TableKit+MasterSelectionBindingTests.swift in Sources */,
 				5B4ABD3A2257365C0073FACE /* TableKitTests.swift in Sources */,
 				CDD2A5211F42DE7500E2B78B /* HighlightedTests.swift in Sources */,
 				B35F8B4C1F3783E400904E37 /* CollectionDiffTests.swift in Sources */,

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -472,13 +472,17 @@ public extension MasterDetailSelection where Elements.Index == TableIndex {
             if let index = current?.index {
                 guard let indexPath = IndexPath(index, in: tableKit.table) else { return }
                 let isVisible = tableKit.view.indexPathsForVisibleRows?.contains(indexPath) ?? false
-                let scrollPosition: UITableView.ScrollPosition
-                if let prevIndex = prev?.index {
-                    scrollPosition = (prevIndex < index ? .bottom : .top)
+                if isVisible {
+                    let scrollPosition: UITableView.ScrollPosition
+                    if prev?.index == nil {
+                        scrollPosition = .middle
+                    } else {
+                        scrollPosition = .none
+                    }
+                    tableKit.view.selectRow(at: indexPath, animated: true, scrollPosition: scrollPosition)
                 } else {
-                    scrollPosition = .middle
+                    tableKit.view.deselectRow(at: indexPath, animated: false)
                 }
-                tableKit.view.selectRow(at: indexPath, animated: true, scrollPosition: isVisible ? .none : scrollPosition)
             } else if let prevIndex = prev?.index {
                 guard let indexPath = IndexPath(prevIndex, in: tableKit.table) else { return }
                 tableKit.view.deselectRow(at: indexPath, animated: true)
@@ -488,8 +492,6 @@ public extension MasterDetailSelection where Elements.Index == TableIndex {
         bag += tableKit.delegate.didSelect.onValue { index in
             self.select(index: index)
         }
-
-        tableKit.delegate.shouldAutomaticallyDeselect = false
 
         return bag
     }

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -472,17 +472,13 @@ public extension MasterDetailSelection where Elements.Index == TableIndex {
             if let index = current?.index {
                 guard let indexPath = IndexPath(index, in: tableKit.table) else { return }
                 let isVisible = tableKit.view.indexPathsForVisibleRows?.contains(indexPath) ?? false
-                if isVisible {
-                    let scrollPosition: UITableView.ScrollPosition
-                    if prev?.index == nil {
-                        scrollPosition = .middle
-                    } else {
-                        scrollPosition = .none
-                    }
-                    tableKit.view.selectRow(at: indexPath, animated: true, scrollPosition: scrollPosition)
+                let scrollPosition: UITableView.ScrollPosition
+                if let prevIndex = prev?.index {
+                    scrollPosition = (prevIndex < index ? .bottom : .top)
                 } else {
-                    tableKit.view.deselectRow(at: indexPath, animated: false)
+                    scrollPosition = .middle
                 }
+                tableKit.view.selectRow(at: indexPath, animated: true, scrollPosition: isVisible ? .none : scrollPosition)
             } else if let prevIndex = prev?.index {
                 guard let indexPath = IndexPath(prevIndex, in: tableKit.table) else { return }
                 tableKit.view.deselectRow(at: indexPath, animated: true)
@@ -492,6 +488,8 @@ public extension MasterDetailSelection where Elements.Index == TableIndex {
         bag += tableKit.delegate.didSelect.onValue { index in
             self.select(index: index)
         }
+
+        tableKit.delegate.shouldAutomaticallyDeselect = false
 
         return bag
     }

--- a/FormTests/TableKit+MasterSelectionBindingTests.swift
+++ b/FormTests/TableKit+MasterSelectionBindingTests.swift
@@ -1,0 +1,122 @@
+//
+//  Copyright © 2019 iZettle. All rights reserved.
+//
+
+import XCTest
+import Flow
+@testable import Form
+
+class TableKitMasterSelectionBindingTests: XCTestCase {
+    func testStateAfterBinding_noInitialSelection() {
+        let kit = createTableKit(numberOfRows: 10, visibleRows: 5)
+
+        let signal = ReadWriteSignal<TableIndex?>(nil)
+
+        XCTAssertNil(kit.view.indexPathForSelectedRow)
+        let disposable = signal.bindTo(kit, animateSelectionChange: false, select: { _ in })
+        XCTAssertNil(kit.view.indexPathForSelectedRow)
+
+        disposable.dispose()
+    }
+
+    func testStateAfterBinding_initialSelection() {
+        let kit = createTableKit(numberOfRows: 10, visibleRows: 5)
+
+        let index = TableIndex(section: 0, row: 1)
+        let signal = ReadWriteSignal<TableIndex?>(index)
+
+        XCTAssertNil(kit.view.indexPathForSelectedRow)
+        let disposable = signal.bindTo(kit, animateSelectionChange: false, select: { _ in })
+        XCTAssertEqual(kit.view.indexPathForSelectedRow, IndexPath(row: 1, section: 0))
+
+        disposable.dispose()
+    }
+
+    func testStateAfterSelectionChange_withinBounds() {
+        let kit = createTableKit(numberOfRows: 10, visibleRows: 5)
+
+        let index = TableIndex(section: 0, row: 1)
+        let signal = ReadWriteSignal<TableIndex?>(index)
+        let disposable = signal.bindTo(kit, animateSelectionChange: false, select: { _ in })
+
+        signal.value = TableIndex(section: 0, row: 9)
+        XCTAssertEqual(kit.view.indexPathForSelectedRow, IndexPath(row: 9, section: 0))
+
+        disposable.dispose()
+    }
+
+    func testStateAfterSelectionChange_outOfBounds() {
+        let kit = createTableKit(numberOfRows: 10, visibleRows: 5)
+
+        let index = TableIndex(section: 0, row: 1)
+        let signal = ReadWriteSignal<TableIndex?>(index)
+        let disposable = signal.bindTo(kit, animateSelectionChange: false, select: { _ in })
+
+        signal.value = TableIndex(section: 0, row: 10)
+        XCTAssertEqual(kit.view.indexPathForSelectedRow, IndexPath(row: 1, section: 0))
+
+        disposable.dispose()
+    }
+
+    func testStateAfterRemovingSelection() {
+        let kit = createTableKit(numberOfRows: 10, visibleRows: 5)
+
+        let index = TableIndex(section: 0, row: 1)
+        let signal = ReadWriteSignal<TableIndex?>(index)
+
+        let disposable = signal.bindTo(kit, animateSelectionChange: false, select: { _ in })
+        XCTAssertNotNil(kit.view.indexPathForSelectedRow)
+
+        signal.value = nil
+        XCTAssertNil(kit.view.indexPathForSelectedRow)
+
+        disposable.dispose()
+    }
+
+    func testThatSelectionChangeRevealsRow() {
+        let kit = createTableKit(numberOfRows: 10, visibleRows: 5)
+
+        let index = TableIndex(section: 0, row: 2)
+        let signal = ReadWriteSignal<TableIndex?>(index)
+        let disposable = signal.bindTo(kit, animateSelectionChange: false, select: { _ in })
+
+        kit.view.scrollToBottom(animated: false)
+        XCTAssertFalse(kit.view.areSelectedRowsVisible)
+
+        signal.value = TableIndex(section: 0, row: 1)
+        XCTAssertTrue(kit.view.areSelectedRowsVisible)
+
+        disposable.dispose()
+    }
+
+    func testThatSameSelectionDoesNotRevealRow() {
+        let kit = createTableKit(numberOfRows: 10, visibleRows: 5)
+
+        let index = TableIndex(section: 0, row: 1)
+        let signal = ReadWriteSignal<TableIndex?>(index)
+        let disposable = signal.bindTo(kit, animateSelectionChange: false, select: { _ in })
+
+        kit.view.scrollToBottom(animated: false)
+        XCTAssertFalse(kit.view.areSelectedRowsVisible)
+
+        signal.value = index
+        XCTAssertFalse(kit.view.areSelectedRowsVisible)
+
+        disposable.dispose()
+    }
+
+    func createTableKit(numberOfRows: Int, visibleRows: Int) -> TableKit<EmptySection, Int> {
+        let kit: TableKit! = TableKit(table: Table(rows: Array(1...numberOfRows))) { _, _ in UITableViewCell() }
+        kit.view.frame.size = kit.view.systemLayoutSizeFitting(UIView.layoutFittingExpandedSize)
+        kit.view.frame.size.height = (kit.view.visibleCells.first?.frame.size.height ?? 0) * CGFloat(visibleRows)
+        return kit
+    }
+}
+
+extension UITableView {
+    var areSelectedRowsVisible: Bool {
+        let selectedRows = Set(indexPathsForSelectedRows ?? [])
+        let visibleRows = Set(indexPathsForVisibleRows ?? [])
+        return selectedRows.isSubset(of: visibleRows)
+    }
+}


### PR DESCRIPTION
During the work on a feature that has paging I've faced the next bug: after fetching more items table is being scrolled to the top to a previously selected item. This happens because in ```func bindTo<Row, Section>(_ tableKit: TableKit<Row, Section>)``` we do not take in consideration that selected element might be no longer visible. In this case this element should be deselected. 
I've tested this fix in a couple of places and it seems to work, but I would appreciate more testing since this function is confusing and has a lot of conditions.