### PR TITLE
Bump version to 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.3
+- Improvement: Improved size class handling to better support iPad multitasking, removed all hard references to device type.
+
 ## 2.0.2
 - Bugfix: Fix issue with `scrollToRevealFirstResponder` ([#122](https://github.com/iZettle/Form/issues/122))
 

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>2.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "2.0.2"
+  s.version      = "2.0.3"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>2.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
## 2.0.3
- Improvement: Improved size class handling to better support iPad multitasking, removed all hard references to device type.
- Tech: Moved CI build and test completely to CircleCI config.yml