### PR TITLE
Prevent TableKit scrolling on row selection when no rows are visible

### DIFF
--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -485,7 +485,19 @@ public extension SignalProvider where Kind.DropWrite == Read, Value == TableInde
                 guard let indexPath = IndexPath(index, in: tableKit.table) else {
                     return
                 }
-                let isVisible = tableKit.view.indexPathsForVisibleRows?.contains(indexPath) ?? false
+
+                // select the row
+                tableKit.view.selectRow(at: indexPath, animated: animateSelectionChange, scrollPosition: .none)
+
+                // try to scroll to the selected row
+                guard
+                    let indexPathsForVisibleRows = tableKit.view.indexPathsForVisibleRows,
+                    !indexPathsForVisibleRows.isEmpty
+                else {
+                    return
+                }
+
+                let isVisible = indexPathsForVisibleRows.contains(indexPath)
                 let scrollPosition: UITableView.ScrollPosition
 
                 switch (prev, isVisible) {
@@ -510,11 +522,15 @@ public extension SignalProvider where Kind.DropWrite == Read, Value == TableInde
                     scrollPosition = .middle
                 }
 
-                tableKit.view.selectRow(at: indexPath, animated: animateSelectionChange, scrollPosition: scrollPosition)
+                // .none does not mean no scrolling will occur
+                if scrollPosition != .none {
+                    tableKit.view.scrollToRow(at: indexPath, at: scrollPosition, animated: animateSelectionChange)
+                }
             } else if let prevIndex = prev {
                 guard let indexPath = IndexPath(prevIndex, in: tableKit.table) else {
                     return
                 }
+
                 tableKit.view.deselectRow(at: indexPath, animated: animateSelectionChange)
             }
         }


### PR DESCRIPTION
This PR fixes an issue with edge case in the `TableKit` selection binding that was not handled correctly. Specifically, when an item was selected right after the initial data source update the binding code would try to scroll the newly selected item to the middle which caused the table view to jump. 

In the example demonstrated below the first row (i.e., with index <0, 0> and title "November") is supposed to be selected and made visible when clicking the "By month" segment:

![before](https://user-images.githubusercontent.com/4421971/69583404-1a329b00-0fdb-11ea-8ae5-49d5eb3dc3b6.gif)

The first row is selected but scrolled out of visibility. Apparently, at this early stage `UITableView.indexPathsForVisibleRows` is still empty, so the newly selected row is incorrectly assumed to be invisible, so the logic that we have tries to scroll the table to the middle. 

I tried [the workaround](https://stackoverflow.com/a/5617546/1318939) suggested on StackOverflow, but it didn't help. Instead I changed the code so that we select the row without scrolling first, and then if `UITableView.indexPathsForVisibleRows` is not nil or empty we try to scroll to it. This seems to have fixed the issue:

![after](https://user-images.githubusercontent.com/4421971/69586673-96c97780-0fe3-11ea-8bbc-98575eb09982.gif)