### PR TITLE
[2.0.6] Safety checks around indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.6
+- Bugfix: Prevent corner case tablekit crash when the table is updated while reloading the view
+
 ## 2.0.5
 - Bugfix: Prevent TableKit scrolling on row selection when no rows are visible (see #145).
 

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.5</string>
+	<string>2.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -235,7 +235,7 @@ public final class TableKit<Section, Row> {
 
         if let hfs = headerForSection {
             bag += delegate.viewForHeaderInSection.set { [weak self] section in
-                guard let `self` = self else { return nil }
+                guard let `self` = self, section < self.table.sections.count else { return nil }
                 return hfs(self.view, self.table.sections[section].value)
             }
         } else {
@@ -246,7 +246,7 @@ public final class TableKit<Section, Row> {
 
         if let ffs = footerForSection {
             bag += delegate.viewForFooterInSection.set { [weak self] section in
-                guard let `self` = self else { return nil }
+                guard let `self` = self, section < self.table.sections.count else { return nil }
                 return ffs(self.view, self.table.sections[section].value)
             }
         } else {

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "2.0.5"
+  s.version      = "2.0.6"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.5</string>
+	<string>2.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormTests/TableChangeTests.swift
+++ b/FormTests/TableChangeTests.swift
@@ -88,12 +88,33 @@ class TableChangeTests: XCTestCase {
     }
 
     func testSectionInsertAndRemove() {
-        test(from: [("A", [1])], to: [("A", [1]), ("B", [1])])
-        test(from: [("A", [1])], to: [("A", [1]), ("B", [1]), ("C", [1])])
-        test(from: [("B", [1])], to: [("A", [1]), ("B", [1])])
-        test(from: [("C", [1])], to: [("A", [1]), ("B", [1]), ("C", [1])])
-        test(from: [("B", [1])], to: [("A", [1]), ("B", [1]), ("C", [1])])
-        test(from: [("C", [1]), ("B", [1]), ("A", [1])], to: [("A", [1]), ("B", [1]), ("C", [1])])
+        test(from: [("A", [1])], to: [("A", [1]), ("B", [1])]) // insert at the end
+        test(from: [("A", [1])], to: [("A", [1]), ("B", [1]), ("C", [1])]) // insert at the end
+        test(from: [("B", [1])], to: [("A", [1]), ("B", [1])]) // insert at the beginning
+        test(from: [("C", [1])], to: [("A", [1]), ("B", [1]), ("C", [1])]) // insert at the beginning
+        test(from: [("B", [1])], to: [("A", [1]), ("B", [1]), ("C", [1])]) // insert at the end and at the beginning
+
+        test(from: [("A", [1]), ("B", [1])], to: [("B", [1])]) // remove first
+        test(from: [("A", [1]), ("B", [1])], to: [("A", [1])]) // remove last
+
+        test(from: [("C", [1]), ("B", [1]), ("A", [1])], to: [("A", [1]), ("B", [1]), ("C", [1])]) // reorder
+    }
+
+    func testSectionRemove_sectionWithHeaderAndFooter_beforeTableIsLaidOut() {
+        let oldTable = Table(sections: [("1", [0, 1, 2]), ("2", [3, 4])])
+        let newTable = Table(sections: [("1", [0, 1, 2])])
+
+        let tableKit = TableKit<String, Int>(
+            table: oldTable,
+            headerForSection: { _, _ in UILabel() },
+            footerForSection: { _, _ in UILabel() },
+            cellForRow: { _, _ in UITableViewCell() }
+        )
+
+        tableKit.view.frame = window.bounds
+        window.addSubview(tableKit.view)
+
+        tableKit.set(newTable, rowIdentifier: { $0 })
     }
 
     func testSectionAndRowInsertAndRemove() {


### PR DESCRIPTION
I stumbled upon a case in which [setting a new table](https://github.com/iZettle/Form/blob/master/Form/TableKit.swift#L350) that has less sections than the previous one will cause a crash. This happens if the table was not laid out so when it tries to animate the changes it requests a header/footer from the new model before the number of items in section are updated (which happens during the block). 