### PR TITLE
Text style auto scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+- Added: Optional `adjustsFontForContentSizeCategory` property to specify on a TextStyle
+
 ## 2.0.6
 - Bugfix: Prevent corner case tablekit crash when the table is updated while reloading the view
 

--- a/Examples/Demo/Example/CustomStyle.swift
+++ b/Examples/Demo/Example/CustomStyle.swift
@@ -72,10 +72,20 @@ extension UIColor {
 }
 
 extension UIFont {
-    static let normalText = UIFont.systemFont(ofSize: 17, weight: .medium)
-    static let smallText = UIFont.systemFont(ofSize: 14, weight: .regular)
-    static let regularButton = UIFont.systemFont(ofSize: 20, weight: .medium)
-    static let headerText = UIFont.systemFont(ofSize: 14, weight: .medium)
+    static let normalTextStatic: UIFont = {
+        if #available(iOS 10.0, *) {
+            return UIFont.preferredFont(
+                forTextStyle: .body,
+                compatibleWith: UITraitCollection(preferredContentSizeCategory: .large)
+            )
+        } else {
+            return UIFont.systemFont(ofSize: 17, weight: .medium)
+        }
+    }()
+    static let normalText = UIFont.preferredFont(forTextStyle: .body)
+    static let smallText = UIFont.preferredFont(forTextStyle: .callout)
+    static let regularButton = UIFont.preferredFont(forTextStyle: .title3)
+    static let headerText = UIFont.preferredFont(forTextStyle: .subheadline)
 }
 
 extension TextStyle {
@@ -108,7 +118,9 @@ extension ButtonStyle {
 }
 
 extension BarButtonStyle {
-    static let custom = BarButtonStyle(text: TextStyle.normalText.colored(.mintGreenDark))
+    static let custom = BarButtonStyle(text: TextStyle.normalText.colored(.mintGreenDark).restyled {
+        $0.font = .normalTextStatic
+    })
 }
 
 extension SwitchStyle {

--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		7222DD03235A34310036619F /* TableKit+MasterSelectionBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7222DD02235A34310036619F /* TableKit+MasterSelectionBindingTests.swift */; };
 		722EB63723242D37003AA360 /* ScrollViewVerticalContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722EB63623242D37003AA360 /* ScrollViewVerticalContextTests.swift */; };
 		722EB65023266A99003AA360 /* CollectionKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722EB64F23266A99003AA360 /* CollectionKitTests.swift */; };
+		723C684B23A3CEA1008FD4B6 /* UILabel+ScalingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723C684A23A3CEA1008FD4B6 /* UILabel+ScalingTests.swift */; };
 		724EC30D2241513D001F3E11 /* UILabel+StylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */; };
 		7270AFB0201FAB7C004DAAA3 /* ViewLayoutArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */; };
 		72C5ED6F226F432600E32125 /* UIScrollView+PinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */; };
@@ -140,6 +141,7 @@
 		7222DD02235A34310036619F /* TableKit+MasterSelectionBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TableKit+MasterSelectionBindingTests.swift"; sourceTree = "<group>"; };
 		722EB63623242D37003AA360 /* ScrollViewVerticalContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewVerticalContextTests.swift; sourceTree = "<group>"; };
 		722EB64F23266A99003AA360 /* CollectionKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionKitTests.swift; sourceTree = "<group>"; };
+		723C684A23A3CEA1008FD4B6 /* UILabel+ScalingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+ScalingTests.swift"; sourceTree = "<group>"; };
 		724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+StylingTests.swift"; sourceTree = "<group>"; };
 		7270AFAF201FAB7C004DAAA3 /* ViewLayoutArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewLayoutArea.swift; path = Form/ViewLayoutArea.swift; sourceTree = "<group>"; };
 		72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+PinningTests.swift"; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				F604260920B6A47E00BC4CAB /* ParentChildRelationalTests.swift */,
 				F6B81B9320CA906000B6AC39 /* NumberEditorTests.swift */,
 				724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */,
+				723C684A23A3CEA1008FD4B6 /* UILabel+ScalingTests.swift */,
 				72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */,
 				722EB63623242D37003AA360 /* ScrollViewVerticalContextTests.swift */,
 				F62E45B81CABFB5300C6867E /* Info.plist */,
@@ -586,6 +589,7 @@
 			files = (
 				722EB63723242D37003AA360 /* ScrollViewVerticalContextTests.swift in Sources */,
 				CFD2FFE3221323BF002D4D36 /* TextStyleTests.swift in Sources */,
+				723C684B23A3CEA1008FD4B6 /* UILabel+ScalingTests.swift in Sources */,
 				F604260A20B6A47E00BC4CAB /* ParentChildRelationalTests.swift in Sources */,
 				F6B81B9420CA906000B6AC39 /* NumberEditorTests.swift in Sources */,
 				7222DD03235A34310036619F /* TableKit+MasterSelectionBindingTests.swift in Sources */,

--- a/Form/ButtonStyle.swift
+++ b/Form/ButtonStyle.swift
@@ -132,7 +132,7 @@ private extension UIButton {
             }
         }
 
-        if let normalTextStyle = style.states[.normal]?.text {
+        if #available(iOS 10.0, *), let normalTextStyle = style.states[.normal]?.text {
             self.titleLabel?.refreshTextScaling(for: normalTextStyle)
         }
     }

--- a/Form/ButtonStyle.swift
+++ b/Form/ButtonStyle.swift
@@ -91,19 +91,6 @@ extension ButtonStyle {
 }
 
 private extension UIButton {
-    func applyStateStyle(_ style: ButtonStateStyle, forState state: UIControl.State) {
-        setBackgroundImage(style.backgroundImage, for: state)
-        if style.text.isPlain {
-            setTitleColor(style.text.color, for: state)
-            if state == .normal {
-                titleLabel?.styledText = StyledText(text: title(for: .normal) ?? "", style: style.text)
-            }
-        } else {
-            let attrTitle = NSAttributedString(string: title(for: state) ?? "", attributes: style.text.attributes)
-            setAttributedTitle(attrTitle, for: state)
-        }
-    }
-
     func buttonStyle(for state: UIControl.State) -> ButtonStateStyle? {
         switch state {
         case UIControl.State.normal, UIControl.State.disabled, UIControl.State.selected, UIControl.State.highlighted: break
@@ -143,6 +130,10 @@ private extension UIButton {
                 let attrTitle = NSAttributedString(string: title(for: state) ?? "", attributes: style.text.attributes)
                 setAttributedTitle(attrTitle, for: state)
             }
+        }
+
+        if let normalTextStyle = style.states[.normal]?.text {
+            self.titleLabel?.refreshTextScaling(for: normalTextStyle)
         }
     }
 

--- a/Form/Info.plist
+++ b/Form/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.6</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Form/SectionStyle.swift
+++ b/Form/SectionStyle.swift
@@ -63,8 +63,8 @@ public extension DynamicSectionStyle {
     static let systemGrouped = DynamicSectionStyle { Style(traits: $0, isGrouped: true) }
     static let systemPlain = DynamicSectionStyle { Style(traits: $0, isGrouped: false) }
 
-    static let defaultGrouped = DefaultStyling.current.sectionGrouped
-    static let defaultPlain = DefaultStyling.current.sectionPlain
+    static var defaultGrouped: DynamicSectionStyle { DefaultStyling.current.sectionGrouped }
+    static var defaultPlain: DynamicSectionStyle { DefaultStyling.current.sectionPlain }
 
     static var `default`: DynamicSectionStyle { return defaultGrouped }
 }

--- a/Form/SectionStyle.swift
+++ b/Form/SectionStyle.swift
@@ -63,8 +63,8 @@ public extension DynamicSectionStyle {
     static let systemGrouped = DynamicSectionStyle { Style(traits: $0, isGrouped: true) }
     static let systemPlain = DynamicSectionStyle { Style(traits: $0, isGrouped: false) }
 
-    static var defaultGrouped: DynamicSectionStyle { DefaultStyling.current.sectionGrouped }
-    static var defaultPlain: DynamicSectionStyle { DefaultStyling.current.sectionPlain }
+    static var defaultGrouped: DynamicSectionStyle { return DefaultStyling.current.sectionGrouped }
+    static var defaultPlain: DynamicSectionStyle { return DefaultStyling.current.sectionPlain }
 
     static var `default`: DynamicSectionStyle { return defaultGrouped }
 }

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -100,7 +100,8 @@ public extension TextStyle {
         set { setAttribute(newValue, for: .minimumScaleFactor) }
     }
 
-    /// Indicates whether the object configured with the style should automatically update its font when the device's content size category changes
+    /// Indicates whether the object configured with the style should automatically update its font when the device's content size category changes.
+    /// If `nil`, no changes will be applied to the object preserving its current behaviour (which may vary based on OS version)
     var adjustsFontForContentSizeCategory: Bool? {
         get { return attribute(for: .adjustsFontForContentSizeCategory) }
         set { setAttribute(newValue, for: .adjustsFontForContentSizeCategory) }

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -19,7 +19,15 @@ public struct TextStyle: Style {
 }
 
 public extension TextStyle {
-    init(font: UIFont, color: UIColor, alignment: NSTextAlignment = .natural, numberOfLines: Int = 1, lineBreakMode: NSLineBreakMode = .byTruncatingMiddle, minimumScaleFactor: CGFloat = 0) {
+    init(
+        font: UIFont,
+        color: UIColor,
+        alignment: NSTextAlignment = .natural,
+        numberOfLines: Int = 1,
+        lineBreakMode: NSLineBreakMode = .byTruncatingMiddle,
+        minimumScaleFactor: CGFloat = 0,
+        adjustsFontForContentSizeCategory: Bool? = nil
+    ) {
         // Don't set attributes directly to make sure lookups such as equatableForAttribute is being correctly updated.
         self.font = font
         self.color = color
@@ -27,6 +35,7 @@ public extension TextStyle {
         self.alignment = alignment
         self.lineBreakMode = lineBreakMode
         self.minimumScaleFactor = minimumScaleFactor
+        self.adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory
     }
 }
 

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -16,6 +16,9 @@ public struct TextStyle: Style {
 
     public typealias Attributes = [NSAttributedString.Key: Any]
     public private(set) var attributes: Attributes = [:]
+
+    /// Indicates whether the object configured with the style should automatically update its font when the device's content size category changes
+    public var adjustsFontForContentSizeCategory: Bool = true
 }
 
 public extension TextStyle {

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -16,9 +16,6 @@ public struct TextStyle: Style {
 
     public typealias Attributes = [NSAttributedString.Key: Any]
     public private(set) var attributes: Attributes = [:]
-
-    /// Indicates whether the object configured with the style should automatically update its font when the device's content size category changes
-    public var adjustsFontForContentSizeCategory: Bool = true
 }
 
 public extension TextStyle {
@@ -90,6 +87,12 @@ public extension TextStyle {
     var minimumScaleFactor: CGFloat {
         get { return attribute(for: .minimumScaleFactor) ?? 0 }
         set { setAttribute(newValue, for: .minimumScaleFactor) }
+    }
+
+    /// Indicates whether the object configured with the style should automatically update its font when the device's content size category changes
+    var adjustsFontForContentSizeCategory: Bool? {
+        get { return attribute(for: .adjustsFontForContentSizeCategory) }
+        set { setAttribute(newValue, for: .adjustsFontForContentSizeCategory) }
     }
 
     var highlightedColor: UIColor {
@@ -271,6 +274,7 @@ extension NSAttributedString.Key {
     static let lineSpacing = NSAttributedString.Key(rawValue: "_lineSpacing")
     static let textAlignment = NSAttributedString.Key(rawValue: "_textAligment")
     static let minimumScaleFactor = NSAttributedString.Key(rawValue: "_minimumScaleFactor")
+    static let adjustsFontForContentSizeCategory = NSAttributedString.Key(rawValue: "_adjustsFontForContentSizeCategory")
 }
 
 extension TextStyle {
@@ -308,7 +312,7 @@ private extension TextStyle {
 private var equatableForAttribute = [NSAttributedString.Key: (Any, Any) -> Bool]()
 private var nextTextStyleChangeIndex = 0
 private let plainAttributes: Set<NSAttributedString.Key> = [
-    .foregroundColor, .font, .numberOfLines, .highlightedColor, .lineBreakMode, .textAlignment, .minimumScaleFactor
+    .foregroundColor, .font, .numberOfLines, .highlightedColor, .lineBreakMode, .textAlignment, .minimumScaleFactor, .adjustsFontForContentSizeCategory
 ]
 private var customAttributes = [NSAttributedString.Key: ((NSAttributedString, Any) -> NSAttributedString)]()
 

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -16,6 +16,9 @@ public struct TextStyle: Style {
 
     public typealias Attributes = [NSAttributedString.Key: Any]
     public private(set) var attributes: Attributes = [:]
+
+    // Don't set attributes as custom properties to make sure lookups such as equatableForAttribute is being correctly updated.
+    // When adding attributes that don't need attributed text updates, add them to `plainAttributes`
 }
 
 public extension TextStyle {
@@ -28,7 +31,6 @@ public extension TextStyle {
         minimumScaleFactor: CGFloat = 0,
         adjustsFontForContentSizeCategory: Bool? = nil
     ) {
-        // Don't set attributes directly to make sure lookups such as equatableForAttribute is being correctly updated.
         self.font = font
         self.color = color
         self.numberOfLines = numberOfLines

--- a/Form/UILabel+Styling.swift
+++ b/Form/UILabel+Styling.swift
@@ -68,6 +68,7 @@ public extension UILabel {
     }
 }
 
+@available(iOS 10.0, *)
 internal extension UIContentSizeCategoryAdjusting {
 
     /// Resets the automatic font adjusting to the current value provided by `textStyle`
@@ -75,12 +76,18 @@ internal extension UIContentSizeCategoryAdjusting {
     /// - Note: This is a workaround. UI elements conforming to this protocol usually scale properly when they are on screen when the content size category changes. However when configured for the first time with font that was scaled for different font metrics the adjusting doesn't happen automatically.
     /// - Parameter textStyle: Contains the preference about font content size adjustment
     func refreshTextScaling(for textStyle: TextStyle) {
+        self.adjustsFontForContentSizeCategory = false
+        let adjusts = textStyle.adjustsFontForContentSizeCategory
+        if adjusts {
+            self.adjustsFontForContentSizeCategory = adjusts
+        }
+    }
+}
+
+extension UILabel {
+    func refreshTextScaling() {
         if #available(iOS 10.0, *) {
-            self.adjustsFontForContentSizeCategory = false
-            let adjusts = textStyle.adjustsFontForContentSizeCategory
-            if adjusts {
-                self.adjustsFontForContentSizeCategory = adjusts
-            }
+            self.refreshTextScaling(for: self.style)
         }
     }
 }
@@ -118,7 +125,7 @@ private extension UILabel {
             attributedText = NSAttributedString(styledText: styledText)
         }
 
-        self.refreshTextScaling(for: style)
+        self.refreshTextScaling()
 
         guard let accessibilityIdentifier = styledText.text.accessibilityIdentifier else { return }
         self.accessibilityIdentifier = accessibilityIdentifier

--- a/Form/UILabel+Styling.swift
+++ b/Form/UILabel+Styling.swift
@@ -76,8 +76,9 @@ internal extension UIContentSizeCategoryAdjusting {
     /// - Note: This is a workaround. UI elements conforming to this protocol usually scale properly when they are on screen when the content size category changes. However when configured for the first time with font that was scaled for different font metrics the adjusting doesn't happen automatically.
     /// - Parameter textStyle: Contains the preference about font content size adjustment
     func refreshTextScaling(for textStyle: TextStyle) {
+        let adjustsFont = textStyle.adjustsFontForContentSizeCategory ?? self.adjustsFontForContentSizeCategory
         self.adjustsFontForContentSizeCategory = false
-        if textStyle.adjustsFontForContentSizeCategory {
+        if adjustsFont {
             self.adjustsFontForContentSizeCategory = true
         }
     }

--- a/Form/UILabel+Styling.swift
+++ b/Form/UILabel+Styling.swift
@@ -77,9 +77,8 @@ internal extension UIContentSizeCategoryAdjusting {
     /// - Parameter textStyle: Contains the preference about font content size adjustment
     func refreshTextScaling(for textStyle: TextStyle) {
         self.adjustsFontForContentSizeCategory = false
-        let adjusts = textStyle.adjustsFontForContentSizeCategory
-        if adjusts {
-            self.adjustsFontForContentSizeCategory = adjusts
+        if textStyle.adjustsFontForContentSizeCategory {
+            self.adjustsFontForContentSizeCategory = true
         }
     }
 }

--- a/Form/UILabel+Styling.swift
+++ b/Form/UILabel+Styling.swift
@@ -68,6 +68,23 @@ public extension UILabel {
     }
 }
 
+internal extension UIContentSizeCategoryAdjusting {
+
+    /// Resets the automatic font adjusting to the current value provided by `textStyle`
+    ///
+    /// - Note: This is a workaround. UI elements conforming to this protocol usually scale properly when they are on screen when the content size category changes. However when configured for the first time with font that was scaled for different font metrics the adjusting doesn't happen automatically.
+    /// - Parameter textStyle: Contains the preference about font content size adjustment
+    func refreshTextScaling(for textStyle: TextStyle) {
+        if #available(iOS 10.0, *) {
+            self.adjustsFontForContentSizeCategory = false
+            let adjusts = textStyle.adjustsFontForContentSizeCategory
+            if adjusts {
+                self.adjustsFontForContentSizeCategory = adjusts
+            }
+        }
+    }
+}
+
 private extension UILabel {
     func setStyledText(_ styledText: StyledText) {
         let prevStyledText: StyledText? = associatedValue(forKey: &styledTextKey)
@@ -100,6 +117,8 @@ private extension UILabel {
         } else {
             attributedText = NSAttributedString(styledText: styledText)
         }
+
+        self.refreshTextScaling(for: style)
 
         guard let accessibilityIdentifier = styledText.text.accessibilityIdentifier else { return }
         self.accessibilityIdentifier = accessibilityIdentifier

--- a/Form/UITextField+Styling.swift
+++ b/Form/UITextField+Styling.swift
@@ -59,6 +59,8 @@ public extension UITextField {
             attributedText = NSAttributedString(styledText: styledText)
             attributedPlaceholder = NSAttributedString(text: placeholder ?? "", style: newValue.placeholder)
 
+            self.refreshTextScaling(for: newValue.text)
+
             textAlignment = newValue.text.alignment
 
             self.selectedTextRange = selectedTextRange

--- a/Form/UITextField+Styling.swift
+++ b/Form/UITextField+Styling.swift
@@ -59,7 +59,9 @@ public extension UITextField {
             attributedText = NSAttributedString(styledText: styledText)
             attributedPlaceholder = NSAttributedString(text: placeholder ?? "", style: newValue.placeholder)
 
-            self.refreshTextScaling(for: newValue.text)
+            if #available(iOS 10.0, *) {
+                self.refreshTextScaling(for: newValue.text)
+            }
 
             textAlignment = newValue.text.alignment
 

--- a/FormTests/Info.plist
+++ b/FormTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.6</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/FormTests/UILabel+ScalingTests.swift
+++ b/FormTests/UILabel+ScalingTests.swift
@@ -14,7 +14,8 @@ class UILabelScalingTests: XCTestCase {
 
     func testInitialScaling_plainTextStyle() {
         func makeLabel() -> UILabel {
-            return UILabel(value: "Test", style: .plain)
+            let style = TextStyle.plain.restyled { $0.adjustsFontForContentSizeCategory = true }
+            return UILabel(value: "Test", style: style)
         }
 
         let regularSize = labelPointSizeInScalingWindow(makeLabel(), windowSizeCategory: .large)
@@ -26,7 +27,8 @@ class UILabelScalingTests: XCTestCase {
     }
 
     func testScalingWhenSwitchingSizeCategory_plainTextStyle() {
-        let label = UILabel(value: "Test", style: TextStyle.plain.restyled { $0.adjustsFontForContentSizeCategory = true })
+        let style = TextStyle.plain.restyled { $0.adjustsFontForContentSizeCategory = true }
+        let label = UILabel(value: "Test", style: style)
 
         let regularSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .large)
         let largerSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .extraExtraLarge)
@@ -38,7 +40,8 @@ class UILabelScalingTests: XCTestCase {
 
     func testInitialScaling_customAttributesTextStyle() {
         func makeLabel() -> UILabel {
-            return UILabel(value: "Test", style: .withCustomAttributes)
+            let style = TextStyle.withCustomAttributes.restyled { $0.adjustsFontForContentSizeCategory = true }
+            return UILabel(value: "Test", style: style)
         }
 
         let regularSize = labelPointSizeInScalingWindow(makeLabel(), windowSizeCategory: .large)
@@ -50,7 +53,8 @@ class UILabelScalingTests: XCTestCase {
     }
 
     func testScalingWhenSwitchingSizeCategory_customAttributesTextStyle() {
-        let label = UILabel(value: "Test", style: TextStyle.withCustomAttributes.restyled { $0.adjustsFontForContentSizeCategory = true })
+        let style = TextStyle.withCustomAttributes.restyled { $0.adjustsFontForContentSizeCategory = true }
+        let label = UILabel(value: "Test", style: style)
 
         let regularSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .large)
         let largerSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .extraExtraLarge)

--- a/FormTests/UILabel+ScalingTests.swift
+++ b/FormTests/UILabel+ScalingTests.swift
@@ -1,0 +1,89 @@
+//
+//  UILabel+ScalingTests.swift
+//  FormTests
+//
+//  Created by Nataliya Patsovska on 2019-12-13.
+//  Copyright © 2019 iZettle. All rights reserved.
+//
+
+import XCTest
+import Form
+
+@available(iOS 10.0, *)
+class UILabelScalingTests: XCTestCase {
+
+    func testInitialScaling_plainTextStyle() {
+        func makeLabel() -> UILabel {
+            return UILabel(value: "Test", style: .plain)
+        }
+
+        let regularSize = labelPointSizeInScalingWindow(makeLabel(), windowSizeCategory: .large)
+        let largerSize = labelPointSizeInScalingWindow(makeLabel(), windowSizeCategory: .extraExtraLarge)
+        let smallerSize = labelPointSizeInScalingWindow(makeLabel(), windowSizeCategory: .extraSmall)
+
+        XCTAssertGreaterThan(largerSize, regularSize)
+        XCTAssertLessThan(smallerSize, regularSize)
+    }
+
+    func testScalingWhenSwitchingSizeCategory_plainTextStyle() {
+        let label = UILabel(value: "Test", style: .plain)
+
+        let regularSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .large)
+        let largerSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .extraExtraLarge)
+        let smallerSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .extraSmall)
+
+        XCTAssertGreaterThan(largerSize, regularSize)
+        XCTAssertLessThan(smallerSize, regularSize)
+    }
+
+    func testInitialScaling_customAttributesTextStyle() {
+        func makeLabel() -> UILabel {
+            return UILabel(value: "Test", style: .withCustomAttributes)
+        }
+
+        let regularSize = labelPointSizeInScalingWindow(makeLabel(), windowSizeCategory: .large)
+        let largerSize = labelPointSizeInScalingWindow(makeLabel(), windowSizeCategory: .extraExtraLarge)
+        let smallerSize = labelPointSizeInScalingWindow(makeLabel(), windowSizeCategory: .extraSmall)
+
+        XCTAssertGreaterThan(largerSize, regularSize)
+        XCTAssertLessThan(smallerSize, regularSize)
+    }
+
+    func testScalingWhenSwitchingSizeCategory_customAttributesTextStyle() {
+        let label = UILabel(value: "Test", style: .withCustomAttributes)
+
+        let regularSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .large)
+        let largerSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .extraExtraLarge)
+        let smallerSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .extraSmall)
+
+        XCTAssertGreaterThan(largerSize, regularSize)
+        XCTAssertLessThan(smallerSize, regularSize)
+    }
+
+    // MARK: - Helpers
+
+    func labelPointSizeInScalingWindow(_ label: UILabel, windowSizeCategory: UIContentSizeCategory) -> CGFloat {
+        let window = CustomScalingWindow(sizeCategory: windowSizeCategory)
+        window.addSubview(label)
+        label.frame = window.bounds
+        let pointSize = label.font.pointSize
+        label.removeFromSuperview()
+        return pointSize
+    }
+
+    private class CustomScalingWindow: UIWindow {
+        let sizeCategory: UIContentSizeCategory
+        init(sizeCategory: UIContentSizeCategory) {
+            self.sizeCategory = sizeCategory
+            super.init(frame: UIScreen.main.bounds)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override var traitCollection: UITraitCollection {
+            return UITraitCollection(preferredContentSizeCategory: sizeCategory)
+        }
+    }
+}

--- a/FormTests/UILabel+ScalingTests.swift
+++ b/FormTests/UILabel+ScalingTests.swift
@@ -26,7 +26,7 @@ class UILabelScalingTests: XCTestCase {
     }
 
     func testScalingWhenSwitchingSizeCategory_plainTextStyle() {
-        let label = UILabel(value: "Test", style: .plain)
+        let label = UILabel(value: "Test", style: TextStyle.plain.restyled { $0.adjustsFontForContentSizeCategory = true })
 
         let regularSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .large)
         let largerSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .extraExtraLarge)
@@ -50,7 +50,7 @@ class UILabelScalingTests: XCTestCase {
     }
 
     func testScalingWhenSwitchingSizeCategory_customAttributesTextStyle() {
-        let label = UILabel(value: "Test", style: .withCustomAttributes)
+        let label = UILabel(value: "Test", style: TextStyle.withCustomAttributes.restyled { $0.adjustsFontForContentSizeCategory = true })
 
         let regularSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .large)
         let largerSize = labelPointSizeInScalingWindow(label, windowSizeCategory: .extraExtraLarge)

--- a/FormTests/UILabel+StylingTests.swift
+++ b/FormTests/UILabel+StylingTests.swift
@@ -95,7 +95,7 @@ class UILabelStylingTests: XCTestCase {
     }
 }
 
-private extension TextStyle {
-    static let plain = TextStyle(font: .systemFont(ofSize: 14.0), color: .black)
-    static let withCustomAttributes = TextStyle.plain.restyled { $0.letterSpacing = 1.0 }
+extension TextStyle {
+    static let plain = TextStyle(font: .preferredFont(forTextStyle: .body), color: .black)
+    static let withCustomAttributes = TextStyle.plain.restyled { $0.letterSpacing = 1.0 }.uppercased
 }


### PR DESCRIPTION
## What
Add `adjustsFontForContentSizeCategory` property to `TextStyle` and take it into account when configuring labels.

## Why
One way of supporting dynamic type auto resizing is to rely on the types that implement `UIContentSizeCategoryAdjusting`. A convenient single place where we can set this is where UIKit components are configured with their styles. 

### Alternative
Considered the option of adding it to `DefaultStyling` but it doesn't really fit the purpose of it. It's more of a label style and currently our `TextStyle` encapsulates everything related to labels. Maybe we want to move to a new TextStyle type that encapsulates 2 different subtypes of styling - for the text attributes and one for the text container behaviour? That would be a bigger refactoring that can happen independently if we feel like it's worth it. I think that there is no reason to hold on this improvement even if we decide to go another way in the future. 

## Note
The actual configuration of `adjustsFontForContentSizeCategory` contains a workaround for an issue where attributed string doesn't respond to font changes properly unless the property is set to false and then to true. I guess this triggers some internal updates. I didn't find documentation on the subject. It will be nice to cover that with some tests. Ideas are welcome 💡 .