### PR TITLE
Clear 'shouldResetOnInsertion' when user deletes a character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+- Change: `ValueField`: clear the `.shouldResetOnInsertion` flag when deleting characters.
+
 ## 3.0.0
 - Added: `.shouldResetOnInsertion` to `ValueField`.
 - Added: `reset()`, `defaultValue`, and `.shouldResetOnInsertion` to the `TextEditor` protocol (breaking change).

--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -851,7 +851,7 @@
 				INFOPLIST_FILE = Form/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Form;
 				PRODUCT_NAME = Form;
 				SKIP_INSTALL = YES;
@@ -872,7 +872,7 @@
 				INFOPLIST_FILE = Form/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Form;
 				PRODUCT_NAME = Form;
 				SKIP_INSTALL = YES;

--- a/Form/NumberEditor.swift
+++ b/Form/NumberEditor.swift
@@ -94,6 +94,7 @@ extension NumberEditor: TextEditor {
             }
         }
 
+        shouldResetOnInsertion = false
         deleteLast()
     }
 }

--- a/Form/ValueEditor.swift
+++ b/Form/ValueEditor.swift
@@ -62,9 +62,13 @@ public struct ValueEditor<Value>: TextEditor {
     }
 
     mutating public func deleteBackward() {
+        shouldResetOnInsertion = false
+
         var text = valueToText(value)
         guard text.count > minCharacters else { return }
+
         text.remove(at: text.index(before: text.endIndex))
+
         if let value = textToValue(text) {
             self.value = value
         }

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "3.0.0"
+  s.version      = "3.0.1"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC

--- a/FormTests/NumberEditorTests.swift
+++ b/FormTests/NumberEditorTests.swift
@@ -241,7 +241,7 @@ class DecimalEditorTests: XCTestCase {
         test(editor, "12RRR3", "3", 3, 0)
         test(editor, "12R23R34R45", "45", 45, 0)
         test(editor, "12R<", "1", 1, 0)
-        test(editor, "12R<3", "3", 3, 0)
+        test(editor, "12R<3", "13", 13, 0)
         test(editor, "12RR<3", "13", 13, 0)
         test(editor, "12R34r", "0", 0, 0)
         test(editor, "12R\n", "12", 12, 0)

--- a/FormTests/ValueEditorTests.swift
+++ b/FormTests/ValueEditorTests.swift
@@ -76,7 +76,7 @@ class ValueEditorTests: XCTestCase {
         test(editor, "12RRR3", "3", 0)
         test(editor, "12R23R34R45", "45", 0)
         test(editor, "12R<", "1", 0)
-        test(editor, "12R<3", "3", 0)
+        test(editor, "12R<3", "13", 0)
         test(editor, "12RR<3", "13", 0)
         test(editor, "12R34r", "", 0)
     }


### PR DESCRIPTION
When the `.shouldResetOnInsertion` flag is set on `ValueField`, the current behavior is to not reset it when user presses Backspace. In this case when a character is inserted the field will reset its contents instead of appending the character, which is most likely not what the user expects, an issue this PR fixes.