### PR TITLE
Fix recursive issue caused by two pinned views

### DIFF
--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -248,21 +248,11 @@ private extension UIScrollView {
             }
         }
 
-        // Bring view to front whenever subviews are updated,
+        // Bring view to front whenever subviews are added,
         // but make sure we're not causing two pinned views to
         // infinitely compete for the last index.
-        bag += subviewsSignal.onValue { subviews in
-            guard let index = subviews.firstIndex(of: view) else { return }
-
-            let subsequentSubviews = Array(subviews.dropFirst(Int(index) + 1))
-
-            guard !subsequentSubviews.isEmpty else { return }
-
-            let intersectingSubviews = subsequentSubviews.filter { $0.frame.intersects(view.frame) }
-
-            if !intersectingSubviews.isEmpty {
-                self.bringSubviewToFront(view)
-            }
+        bag += subviewsSignal.map { Set($0) }.distinct().onValue { _ in
+            self.bringSubviewToFront(view)
         }
 
         // The parent moved between views when being presented and dismissed etc.

--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -121,8 +121,21 @@ public extension UIScrollView {
             }
         }
 
-        bag += subviewsSignal.onValue { _ in
-            self.bringSubviewToFront(view)
+        // Bring view to front whenever subviews are updated,
+        // but make sure we're not causing two pinned views to
+        // infinitely compete for the last index.
+        bag += subviewsSignal.onValue { subviews in
+            guard let index = subviews.firstIndex(of: view) else { return }
+
+            let subsequentSubviews = Array(subviews.dropFirst(Int(index) + 1))
+
+            guard !subsequentSubviews.isEmpty else { return }
+
+            let intersectingSubviews = subsequentSubviews.filter { $0.frame.intersects(view.frame) }
+
+            if !intersectingSubviews.isEmpty {
+                self.bringSubviewToFront(view)
+            }
         }
 
         constraints += [fix, spring].compactMap { $0 }
@@ -245,8 +258,21 @@ private extension UIScrollView {
             }
         }
 
-        bag += subviewsSignal.onValue { _ in
-            self.bringSubviewToFront(view)
+        // Bring view to front whenever subviews are updated,
+        // but make sure we're not causing two pinned views to
+        // infinitely compete for the last index.
+        bag += subviewsSignal.onValue { subviews in
+            guard let index = subviews.firstIndex(of: view) else { return }
+
+            let subsequentSubviews = Array(subviews.dropFirst(Int(index) + 1))
+
+            guard !subsequentSubviews.isEmpty else { return }
+
+            let intersectingSubviews = subsequentSubviews.filter { $0.frame.intersects(view.frame) }
+
+            if !intersectingSubviews.isEmpty {
+                self.bringSubviewToFront(view)
+            }
         }
 
         // The parent moved between views when being presented and dismissed etc.

--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -98,7 +98,7 @@ public extension UIScrollView {
             }
 
         case .top:
-            precondition(self[insets: insetKey].bottom == 0, "Only one view can be pinned to top")
+            precondition(self[insets: insetKey].top == 0, "Only one view can be pinned to top")
             bag += viewHeight.atOnce().onValue { height in
                 self[insets: insetKey].top = height
             }

--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -121,21 +121,11 @@ public extension UIScrollView {
             }
         }
 
-        // Bring view to front whenever subviews are updated,
+        // Bring view to front whenever subviews are added,
         // but make sure we're not causing two pinned views to
         // infinitely compete for the last index.
-        bag += subviewsSignal.onValue { subviews in
-            guard let index = subviews.firstIndex(of: view) else { return }
-
-            let subsequentSubviews = Array(subviews.dropFirst(Int(index) + 1))
-
-            guard !subsequentSubviews.isEmpty else { return }
-
-            let intersectingSubviews = subsequentSubviews.filter { $0.frame.intersects(view.frame) }
-
-            if !intersectingSubviews.isEmpty {
-                self.bringSubviewToFront(view)
-            }
+        bag += subviewsSignal.map { Set($0) }.distinct().onValue { _ in
+            self.bringSubviewToFront(view)
         }
 
         constraints += [fix, spring].compactMap { $0 }

--- a/FormTests/UIScrollView+PinningTests.swift
+++ b/FormTests/UIScrollView+PinningTests.swift
@@ -10,6 +10,7 @@ class UIScrollViewPinningTests: XCTestCase {
     let bag = DisposeBag()
 
     override func tearDown() {
+        super.tearDown()
         bag.dispose()
     }
 
@@ -42,7 +43,7 @@ class UIScrollViewPinningTests: XCTestCase {
     func testPinningTopAndBottom_noInfiniteLoop() { // TODO: Messy, clean me up!
         let scrollViewOffset: CGFloat = 50
         let (scrollView, container) = makeEmbeddedScrollView(
-            size: CGSize(width: 200 * 2, height: 200 * 2),
+            size: CGSize(width: 400, height: 400),
             scrollViewOffset: scrollViewOffset
         )
 


### PR DESCRIPTION
If two views are pinned to a scroll view (one to the top, one to the bottom), we may currently cause a recursive loop where the two pinned views may indefinitely compete for the top layer in the view hierarchy.

This has probably not been spotted so far since the unit tests dispose of the observation immediately. In longer-lived views however this is reproducible and it will effectively lock the main thread.

The solution is not to use subview `tag`s to keep track of pinned subviews... (which would be irresponsible) but instead to check that we are indeed competing with _overlapping_ subviews on top. If there's a more straightforward solution I'm all ears. :)

I wrote a failing unit test, and then made it pass using this implementation change. (It could use some cleaning up though.)