### PR TITLE
Fix ValueField.shouldResetOnInsertion not working for max length values

### DIFF
--- a/Form/NumberEditor.swift
+++ b/Form/NumberEditor.swift
@@ -55,7 +55,11 @@ extension NumberEditor: TextEditor {
     mutating public func insertCharacter(_ char: Character) {
         let maxLength = formatter.maximumIntegerDigits + minimumFractionDigits
 
-        guard internalText.count < maxLength || char == decimalCharacter || (alwaysShowsDecimalSeparator && minFractionDigits == 0) else {
+        guard
+            (internalText.count < maxLength || shouldResetOnInsertion) ||
+            char == decimalCharacter ||
+            (alwaysShowsDecimalSeparator && minFractionDigits == 0)
+        else {
             return
         }
 
@@ -64,17 +68,17 @@ extension NumberEditor: TextEditor {
         if formatter.maximumFractionDigits > 0 && char == decimalCharacter {
             alwaysShowsDecimalSeparator = true
         } else if Int(insertStr) != nil {
+            if shouldResetOnInsertion {
+                shouldResetOnInsertion = false
+                reset()
+            }
+
             if minFractionDigits <= 0 && formatter.maximumFractionDigits > 0 { // Rewrite guard
                 guard minimumFractionDigits < formatter.maximumFractionDigits else { return }
 
                 if alwaysShowsDecimalSeparator {
                     minimumFractionDigits += 1
                 }
-            }
-
-            if shouldResetOnInsertion {
-                shouldResetOnInsertion = false
-                reset()
             }
 
             append(char)

--- a/FormTests/NumberEditorTests.swift
+++ b/FormTests/NumberEditorTests.swift
@@ -246,4 +246,14 @@ class DecimalEditorTests: XCTestCase {
         test(editor, "12R34r", "0", 0, 0)
         test(editor, "12R\n", "12", 12, 0)
     }
+
+    func testResetOnInsertion_whenValueHasMaximumCharacters_resetsOnInput() {
+        let formatter = decimalFormatter
+        formatter.maximumIntegerDigits = 5
+        formatter.maximumFractionDigits = 3
+
+        let editor = NumberEditor(formatter: formatter)
+        test(editor, "123456R3", "3", 3, 0)
+        test(editor, "12345.6788R9", "9", 9, 0)
+    }
 }

--- a/FormTests/ValueEditorTests.swift
+++ b/FormTests/ValueEditorTests.swift
@@ -80,4 +80,11 @@ class ValueEditorTests: XCTestCase {
         test(editor, "12RR<3", "13", 0)
         test(editor, "12R34r", "", 0)
     }
+
+    func testResetOnInsertion_whenValueHasMaximumCharacters_resetsOnInput() {
+        let editor = ValueEditor<String>(maxCharacters: 5)
+
+        test(editor, "1234567890", "12345", 0)
+        test(editor, "123456R3", "3", 0)
+    }
 }


### PR DESCRIPTION
This PR fixes an issue with `ValueField`: when the field value has maximum allowed length, setting the `shouldResetOnInsertion` flag and entering another character has no effect, the value is not reset.

#### Steps to reproduce
1. Set max length using a formatter (say, 5 characters).
2. Enter '12345' in the field.
3. Set the `shouldResetOnInsertion` flag to `true`
4. Try to press '6'

The field should replace the current value with '6' is entered, but it doesn't, so the value remains `12345`.