### PR TITLE
Highlight the text in ValueField when shouldResetOnInsertion is enabled

### DIFF
--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		F6DD5CB320A0408000975242 /* ButtonStateStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DD5CB220A0408000975242 /* ButtonStateStyle.swift */; };
 		F6FBC82D20AF197B004BC82A /* SectionBackgroundStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FBC82C20AF197B004BC82A /* SectionBackgroundStyle.swift */; };
 		F704C9662436411200208560 /* ValueEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F704C9652436411200208560 /* ValueEditorTests.swift */; };
+		F7315ED6250A316400F393F4 /* ValueFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7315ED5250A316400F393F4 /* ValueFieldTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -229,6 +230,7 @@
 		F6DD5CB220A0408000975242 /* ButtonStateStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ButtonStateStyle.swift; path = Form/ButtonStateStyle.swift; sourceTree = "<group>"; };
 		F6FBC82C20AF197B004BC82A /* SectionBackgroundStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SectionBackgroundStyle.swift; path = Form/SectionBackgroundStyle.swift; sourceTree = "<group>"; };
 		F704C9652436411200208560 /* ValueEditorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueEditorTests.swift; sourceTree = "<group>"; };
+		F7315ED5250A316400F393F4 /* ValueFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueFieldTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -285,6 +287,7 @@
 				F604260920B6A47E00BC4CAB /* ParentChildRelationalTests.swift */,
 				F6B81B9320CA906000B6AC39 /* NumberEditorTests.swift */,
 				F704C9652436411200208560 /* ValueEditorTests.swift */,
+				F7315ED5250A316400F393F4 /* ValueFieldTests.swift */,
 				724EC30C2241513D001F3E11 /* UILabel+StylingTests.swift */,
 				723C684A23A3CEA1008FD4B6 /* UILabel+ScalingTests.swift */,
 				72C5ED6E226F432600E32125 /* UIScrollView+PinningTests.swift */,
@@ -604,6 +607,7 @@
 				72C5ED6F226F432600E32125 /* UIScrollView+PinningTests.swift in Sources */,
 				21367C6B1DACDF990021C98F /* TableChangeTests.swift in Sources */,
 				1C2881831F20EE2000666A21 /* SelectViewTests.swift in Sources */,
+				F7315ED6250A316400F393F4 /* ValueFieldTests.swift in Sources */,
 				1CDD56AA1D9C10D7004B0CA9 /* TableTests.swift in Sources */,
 				724EC30D2241513D001F3E11 /* UILabel+StylingTests.swift in Sources */,
 			);

--- a/Form/FieldStyle.swift
+++ b/Form/FieldStyle.swift
@@ -14,6 +14,7 @@ public struct FieldStyle: Style {
     public var placeholder: TextStyle
     public var disabled: TextStyle
     public var cursorColor: UIColor
+    public var textHighlightColor: UIColor?
     public var autocorrection: UITextAutocorrectionType = .default
     public var autocapitalization: UITextAutocapitalizationType = .sentences
     public var clearButton: UITextField.ViewMode = .never
@@ -22,11 +23,12 @@ public struct FieldStyle: Style {
 }
 
 public extension FieldStyle {
-    init(text: TextStyle, placeholder: TextStyle, disabled: TextStyle, cursorColor: UIColor) {
+    init(text: TextStyle, placeholder: TextStyle, disabled: TextStyle, cursorColor: UIColor, textHighlightColor: UIColor? = nil) {
         self.text = text
         self.placeholder = placeholder
         self.disabled = disabled
         self.cursorColor = cursorColor
+        self.textHighlightColor = textHighlightColor
     }
 }
 

--- a/Form/UITextField+Styling.swift
+++ b/Form/UITextField+Styling.swift
@@ -100,6 +100,7 @@ extension FieldStyle {
         placeholder = text.colored(UIColor(white: 0.8, alpha: 1))
         disabled = text.colored(UIColor(white: 0.4, alpha: 1))
         cursorColor = UIColor(red: 0, green: 0.42, blue: 0.9, alpha: 1)
+        textHighlightColor = nil
         autocorrection = textField.autocorrectionType
         autocapitalization = textField.autocapitalizationType
         clearButton = textField.clearButtonMode

--- a/FormTests/ValueFieldTests.swift
+++ b/FormTests/ValueFieldTests.swift
@@ -1,0 +1,156 @@
+//
+//  Copyright © 2020 iZettle. All rights reserved.
+//
+
+import XCTest
+import Flow
+
+@testable import Form
+
+class ValueFieldTests: XCTestCase {
+
+    lazy var window: UIWindow = {
+        let window = UIWindow()
+        window.frame.size = .init(width: 100, height: 100)
+        window.makeKeyAndVisible()
+
+        return window
+    }()
+
+    func createField() -> (ValueField<String>, Disposable) {
+        let field = ValueField(value: "", editor: ValueEditor())
+
+        // add the field to a window so that it can become first responder
+        window.embedView(field)
+
+        return (field, Disposer { field.removeFromSuperview() })
+    }
+
+    func createFieldAndMakeItFirstResponder(
+        beforeMakingFieldFirstResponder: @escaping (ValueField<String>) -> Void,
+        afterMakingFieldFirstResponder: @escaping (ValueField<String>) -> Void,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> XCTestExpectation {
+        let (field, bag) = createField()
+
+        beforeMakingFieldFirstResponder(field)
+
+        _ = field.becomeFirstResponder()
+        let becameFirstResponder = expectation(description: "Responder status changed")
+
+        // the change of first responder may not happen immediately
+        DispatchQueue.main.async {
+            XCTAssert(field.isFirstResponder, file: file, line: line)
+            afterMakingFieldFirstResponder(field)
+
+            bag.dispose()
+            becameFirstResponder.fulfill()
+        }
+
+        return becameFirstResponder
+    }
+
+    func testTextHighlight_whenNotAFirstResponder_isDisabled() {
+        let (field, _) = createField()
+
+        XCTAssertFalse(field.isFirstResponder)
+        XCTAssertFalse(field.shouldHighlightText)
+
+        field.shouldResetOnInsertion = true
+        XCTAssertFalse(field.shouldHighlightText)
+    }
+
+    func testTextHighlight_whenResetOnInsertionIsDisabled_isDisabled() {
+        let fieldBecameFirstResponder = createFieldAndMakeItFirstResponder(
+            beforeMakingFieldFirstResponder: { field in
+                field.shouldResetOnInsertion = false
+                XCTAssertFalse(field.shouldHighlightText)
+            },
+            afterMakingFieldFirstResponder: { field in
+                XCTAssertFalse(field.shouldHighlightText)
+            }
+        )
+
+        wait(for: [fieldBecameFirstResponder], timeout: 1)
+    }
+
+    func testTextHighlight_whenIsAFirstResponderAndResetOnInsertionIsEnabled_isEnabled() {
+        let fieldBecameFirstResponder = createFieldAndMakeItFirstResponder(
+            beforeMakingFieldFirstResponder: { field in
+                field.shouldResetOnInsertion = true
+            },
+            afterMakingFieldFirstResponder: { field in
+                XCTAssert(field.shouldHighlightText)
+            }
+        )
+
+        wait(for: [fieldBecameFirstResponder], timeout: 1)
+    }
+
+    func testTextHighlight_afterTextIsInserted_isDisabled() {
+        let fieldBecameFirstResponder = createFieldAndMakeItFirstResponder(
+            beforeMakingFieldFirstResponder: { field in
+                field.shouldResetOnInsertion = true
+            },
+            afterMakingFieldFirstResponder: { field in
+                field.insertText("foo")
+                XCTAssertFalse(field.shouldHighlightText)
+            }
+        )
+
+        wait(for: [fieldBecameFirstResponder], timeout: 1)
+    }
+
+    func testTextHighlight_afterFieldBecomesAndResignsFirstResponder_isDisabled() {
+        let fieldResignedFirstResponder = expectation(description: "Field resigned first responder")
+
+        let fieldBecameFirstResponder = createFieldAndMakeItFirstResponder(
+            beforeMakingFieldFirstResponder: { field in
+                field.shouldResetOnInsertion = true
+            },
+            afterMakingFieldFirstResponder: { field in
+                XCTAssert(field.shouldHighlightText)
+                _ = field.resignFirstResponder()
+
+                DispatchQueue.main.async {
+                    XCTAssertFalse(field.isFirstResponder)
+                    XCTAssertFalse(field.shouldHighlightText)
+                    fieldResignedFirstResponder.fulfill()
+                }
+            }
+        )
+
+        wait(for: [fieldBecameFirstResponder, fieldResignedFirstResponder], timeout: 1)
+    }
+
+    func testTextHighlight_afterTextIsPasted_isDisabled() {
+        let fieldBecameFirstResponder = createFieldAndMakeItFirstResponder(
+            beforeMakingFieldFirstResponder: { field in
+                UIPasteboard.general.string = "foo"
+                field.shouldResetOnInsertion = true
+            },
+            afterMakingFieldFirstResponder: { field in
+                field.paste(nil)
+                XCTAssertFalse(field.shouldHighlightText)
+            }
+        )
+
+        wait(for: [fieldBecameFirstResponder], timeout: 1)
+    }
+
+    func testTextHighlight_afterTextIsDeleted_isDisabled() {
+        let fieldBecameFirstResponder = createFieldAndMakeItFirstResponder(
+            beforeMakingFieldFirstResponder: { field in
+                field.insertText("foo")
+                field.shouldResetOnInsertion = true
+            },
+            afterMakingFieldFirstResponder: { field in
+                field.deleteBackward()
+                XCTAssertFalse(field.shouldHighlightText)
+            }
+        )
+
+        wait(for: [fieldBecameFirstResponder], timeout: 1)
+    }
+}


### PR DESCRIPTION
### Background

`shouldResetOnInsertion` is a flag that was recently added to `ValueField`. If enabled, the field value will be cleared before inserting text (see #152 for details).

### What has been done?
This PR adds a new behavior: the field value is marked with `style.textHighlightColor` when `shouldResetOnInsertion` is enabled. This should make it clear to the user that the current value will be replaced by the input (as opposed to being appended).

`style.textHighlightColor` is optional and `nil` by default, so for the existing users of `ValueField` nothing will change.

### Demo
![text-highlight-demo](https://user-images.githubusercontent.com/60687290/92741369-d4cf3680-f37e-11ea-9db7-fcb3b0f43245.gif)

