### PR TITLE
Replaced iZettle strings with PayPal equivalents

### DIFF
--- a/Examples/Demo/Example.xcodeproj/project.pbxproj
+++ b/Examples/Demo/Example.xcodeproj/project.pbxproj
@@ -191,7 +191,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1030;
 				LastUpgradeCheck = 0930;
-				ORGANIZATIONNAME = iZettle;
+				ORGANIZATIONNAME = "PayPal Inc.";
 				TargetAttributes = {
 					2A8568CF2344F70A00B9D157 = {
 						CreatedOnToolsVersion = 10.3;

--- a/Examples/Demo/Example/AppDelegate.swift
+++ b/Examples/Demo/Example/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Måns Bernhardt on 2018-04-17.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Demo/Example/Contents.swift
+++ b/Examples/Demo/Example/Contents.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Måns Bernhardt on 2018-05-09.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Demo/Example/CustomStyle.swift
+++ b/Examples/Demo/Example/CustomStyle.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Måns Bernhardt on 2018-06-11.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Demo/Example/Login.swift
+++ b/Examples/Demo/Example/Login.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Måns Bernhardt on 2018-06-12.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Demo/Example/Messages.swift
+++ b/Examples/Demo/Example/Messages.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Måns Bernhardt on 2018-06-12.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Demo/Example/MultilineRows.swift
+++ b/Examples/Demo/Example/MultilineRows.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Nataliya Patsovska on 2019-05-15.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Demo/Example/Tables.swift
+++ b/Examples/Demo/Example/Tables.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Måns Bernhardt on 2018-05-17.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Demo/Example/Values.swift
+++ b/Examples/Demo/Example/Values.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Måns Bernhardt on 2018-06-08.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Demo/ExampleTests/ExampleTests.swift
+++ b/Examples/Demo/ExampleTests/ExampleTests.swift
@@ -3,7 +3,7 @@
 //  ExampleTests
 //
 //  Created by Philipp Otto on 2019-10-02.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/Examples/Messages/Example.xcodeproj/project.pbxproj
+++ b/Examples/Messages/Example.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1030;
 				LastUpgradeCheck = 0930;
-				ORGANIZATIONNAME = iZettle;
+				ORGANIZATIONNAME = "PayPal Inc.";
 				TargetAttributes = {
 					2A8568DD2344F73200B9D157 = {
 						CreatedOnToolsVersion = 10.3;

--- a/Examples/Messages/Example/AppDelegate.swift
+++ b/Examples/Messages/Example/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  Messages
 //
 //  Created by Måns Bernhardt on 2018-04-17.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Messages/Example/ComposeMessage.swift
+++ b/Examples/Messages/Example/ComposeMessage.swift
@@ -3,7 +3,7 @@
 //  Messages
 //
 //  Created by Måns Bernhardt on 2018-04-19.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Messages/Example/MessageDetails.swift
+++ b/Examples/Messages/Example/MessageDetails.swift
@@ -3,7 +3,7 @@
 //  Messages
 //
 //  Created by Måns Bernhardt on 2018-04-19.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Messages/Example/Messages.swift
+++ b/Examples/Messages/Example/Messages.swift
@@ -3,7 +3,7 @@
 //  Messages
 //
 //  Created by Måns Bernhardt on 2018-04-19.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/Messages/ExampleTests/ExampleTests.swift
+++ b/Examples/Messages/ExampleTests/ExampleTests.swift
@@ -3,7 +3,7 @@
 //  ExampleTests
 //
 //  Created by Philipp Otto on 2019-10-02.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/Examples/SwiftPackageManager/Example.xcodeproj/project.pbxproj
+++ b/Examples/SwiftPackageManager/Example.xcodeproj/project.pbxproj
@@ -100,7 +100,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1100;
-				ORGANIZATIONNAME = iZettle;
+				ORGANIZATIONNAME = "PayPal Inc.";
 				TargetAttributes = {
 					536D90F72338FE5C0070F3D5 = {
 						CreatedOnToolsVersion = 11.0;

--- a/Examples/SwiftPackageManager/Example/AppDelegate.swift
+++ b/Examples/SwiftPackageManager/Example/AppDelegate.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Robin Enhorn on 2019-09-23.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/SwiftPackageManager/Example/SceneDelegate.swift
+++ b/Examples/SwiftPackageManager/Example/SceneDelegate.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Robin Enhorn on 2019-09-23.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Examples/SwiftPackageManager/Example/ViewController.swift
+++ b/Examples/SwiftPackageManager/Example/ViewController.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Robin Enhorn on 2019-09-23.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -502,7 +502,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 1020;
-				ORGANIZATIONNAME = iZettle;
+				ORGANIZATIONNAME = "PayPal Inc.";
 				TargetAttributes = {
 					F62E45B31CABFB5300C6867E = {
 						CreatedOnToolsVersion = 7.3;

--- a/Form/AffixView.swift
+++ b/Form/AffixView.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-01-15.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/AssociatedValues.swift
+++ b/Form/AssociatedValues.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-08-26.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Form/BackgroundStyle.swift
+++ b/Form/BackgroundStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-10-25.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/BarButtonStyle.swift
+++ b/Form/BarButtonStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-25.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/BorderStyle.swift
+++ b/Form/BorderStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-20.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ButtonStateStyle.swift
+++ b/Form/ButtonStateStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-25.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ButtonStyle.swift
+++ b/Form/ButtonStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-25.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/Collection+Changes.swift
+++ b/Form/Collection+Changes.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Said Sikira on 8/5/17.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 /// Defines step in a diffing process

--- a/Form/CollectionAnimation.swift
+++ b/Form/CollectionAnimation.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2017-10-10.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/CollectionKit.swift
+++ b/Form/CollectionKit.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2017-10-10.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/CollectionViewDataSource.swift
+++ b/Form/CollectionViewDataSource.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2017-09-28.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/CollectionViewDelegate.swift
+++ b/Form/CollectionViewDelegate.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2017-09-28.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/Constraints.swift
+++ b/Form/Constraints.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-11-27.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/DefaultStyling.swift
+++ b/Form/DefaultStyling.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-02-25.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/DisplayableString.swift
+++ b/Form/DisplayableString.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-12-05.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/FieldStyle.swift
+++ b/Form/FieldStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-10-16.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/Form.h
+++ b/Form/Form.h
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-12-08.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/Form/FormStyle.swift
+++ b/Form/FormStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-10-22.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/FormView.swift
+++ b/Form/FormView.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-10-22.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/GestureRecognizerDelegate.swift
+++ b/Form/GestureRecognizerDelegate.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2018-10-26.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import Flow

--- a/Form/HeaderFooterStyle.swift
+++ b/Form/HeaderFooterStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-10-24.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/Highlightable.swift
+++ b/Form/Highlightable.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-08-11.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/InsettedStyle.swift
+++ b/Form/InsettedStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-20.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/KeyboardAnimation.swift
+++ b/Form/KeyboardAnimation.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-12-02.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/KeyboardEvent.swift
+++ b/Form/KeyboardEvent.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-12-02.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/MixedReusable.swift
+++ b/Form/MixedReusable.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2018-08-31.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/NavigationBarPosition.swift
+++ b/Form/NavigationBarPosition.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-12-09.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/NumberEditor.swift
+++ b/Form/NumberEditor.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-02-25.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Form/ParentChildRelational.swift
+++ b/Form/ParentChildRelational.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-09-17.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/Reusable.swift
+++ b/Form/Reusable.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-09-27.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/RowAndProvider.swift
+++ b/Form/RowAndProvider.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-26.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/RowView.swift
+++ b/Form/RowView.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-26.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/RowsSelection.swift
+++ b/Form/RowsSelection.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-08-10.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ScrollViewDelegate.swift
+++ b/Form/ScrollViewDelegate.swift
@@ -1,6 +1,6 @@
 //
 // Created by Niil Öhlin on 2018-07-12.
-// Copyright (c) 2018 iZettle. All rights reserved.
+// Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/SectionBackgroundStyle.swift
+++ b/Form/SectionBackgroundStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-10-25.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/SectionStyle.swift
+++ b/Form/SectionStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-10-22.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/SectionView.swift
+++ b/Form/SectionView.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-10-22.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/SegmentedControlStyle.swift
+++ b/Form/SegmentedControlStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Linnea Rönnqvist on 29/07/16.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/SelectView.swift
+++ b/Form/SelectView.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-20.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/Selectable.swift
+++ b/Form/Selectable.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2017-08-03.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/SeparatorStyle.swift
+++ b/Form/SeparatorStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-10-22.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/Styling.swift
+++ b/Form/Styling.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-10-22.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/SubviewOrderable.swift
+++ b/Form/SubviewOrderable.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-27.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/SwitchStyle.swift
+++ b/Form/SwitchStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2017-03-13.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/Table.swift
+++ b/Form/Table.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-02-01.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Form/TableAnimatable.swift
+++ b/Form/TableAnimatable.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2017-10-11.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/TableAnimation.swift
+++ b/Form/TableAnimation.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-09-30.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/TableChange.swift
+++ b/Form/TableChange.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-10-12.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-09-30.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/TableViewDataSource.swift
+++ b/Form/TableViewDataSource.swift
@@ -3,7 +3,7 @@
 //  PurchaseHistory
 //
 //  Created by Måns Bernhardt on 2016-01-28.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/TableViewDelegate.swift
+++ b/Form/TableViewDelegate.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-02-02.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/TableViewFormStyle.swift
+++ b/Form/TableViewFormStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-10-25.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/TextEditor.swift
+++ b/Form/TextEditor.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-02-18.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import Foundation

--- a/Form/TextFieldDelegate.swift
+++ b/Form/TextFieldDelegate.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2018-10-17.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import Flow

--- a/Form/TextStyle+Utilities.swift
+++ b/Form/TextStyle+Utilities.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-10-16.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/TextStyle.swift
+++ b/Form/TextStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-11-25.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/TitleSubtitleStyle.swift
+++ b/Form/TitleSubtitleStyle.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2018-05-17.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UICollectionViewCell+Utilities.swift
+++ b/Form/UICollectionViewCell+Utilities.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2017-10-02.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIEdgeInsets+Utilities.swift
+++ b/Form/UIEdgeInsets+Utilities.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-12-09.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIImage+Styling.swift
+++ b/Form/UIImage+Styling.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 2016-10-17.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UILabel+Styling.swift
+++ b/Form/UILabel+Styling.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-10-16.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIResponders+Utilities.swift
+++ b/Form/UIResponders+Utilities.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-09-17.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIScrollView+Keyboard.swift
+++ b/Form/UIScrollView+Keyboard.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-12-01.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIScrollView+Pinning.swift
+++ b/Form/UIScrollView+Pinning.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-10-26.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIScrollView+Spacing.swift
+++ b/Form/UIScrollView+Spacing.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-08-31.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIStackView+Layout.swift
+++ b/Form/UIStackView+Layout.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-10-14.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UITableView+Utilities.swift
+++ b/Form/UITableView+Utilities.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 21/09/16.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UITableViewCell+Utilities.swift
+++ b/Form/UITableViewCell+Utilities.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-02-02.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UITableViewHeaderFooterView+Utilities.swift
+++ b/Form/UITableViewHeaderFooterView+Utilities.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-02-02.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UITextField+Styling.swift
+++ b/Form/UITextField+Styling.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-10-16.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIView+Embedding.swift
+++ b/Form/UIView+Embedding.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-09-17.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIView+Layout.swift
+++ b/Form/UIView+Layout.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-09-17.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/UIViewController+Install.swift
+++ b/Form/UIViewController+Install.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-09-28.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ValueEditor.swift
+++ b/Form/ValueEditor.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-02-18.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ValueField.swift
+++ b/Form/ValueField.swift
@@ -3,7 +3,7 @@
 //  Flow
 //
 //  Created by Måns Bernhardt on 2016-02-16.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ValueLabel.swift
+++ b/Form/ValueLabel.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2017-01-04.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ViewLayoutArea.swift
+++ b/Form/ViewLayoutArea.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Nataliya Patsovska on 2018-01-29.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ViewPortEvent.swift
+++ b/Form/ViewPortEvent.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2015-12-02.
-//  Copyright © 2015 iZettle. All rights reserved.
+//  Copyright © 2015 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/Form/ViewRepresentable.swift
+++ b/Form/ViewRepresentable.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-09-27.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import UIKit

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
                    DESC
   s.homepage     = "https://github.com/iZettle/Form"
   s.license      = { :type => "MIT", :file => "LICENSE.md" }
-  s.author       = { 'iZettle AB' => 'hello@izettle.com' }
+  s.author       = { 'PayPal Inc.' => 'hello@izettle.com' }
 
   s.ios.deployment_target = "9.0"
   s.dependency 'FlowFramework', '>= 1.8.4'

--- a/FormTests/CollectionDiffTests.swift
+++ b/FormTests/CollectionDiffTests.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Said Sikira on 8/6/17.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/CollectionKitTests.swift
+++ b/FormTests/CollectionKitTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2019 iZettle. All rights reserved.
+// Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/HighlightedTests.swift
+++ b/FormTests/HighlightedTests.swift
@@ -3,7 +3,7 @@
 //  Flow
 //
 //  Created by João D. Moreira on 2017-08-15.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/NumberEditorTests.swift
+++ b/FormTests/NumberEditorTests.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-08-23.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/ParentChildRelationalTests.swift
+++ b/FormTests/ParentChildRelationalTests.swift
@@ -3,7 +3,7 @@
 //  FormTests
 //
 //  Created by Måns Bernhardt on 2018-05-24.
-//  Copyright © 2018 iZettle. All rights reserved.
+//  Copyright © 2018 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/ScrollViewVerticalContextTests.swift
+++ b/FormTests/ScrollViewVerticalContextTests.swift
@@ -3,7 +3,7 @@
 //  FormTests
 //
 //  Created by Nataliya Patsovska on 2019-09-07.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/SelectViewTests.swift
+++ b/FormTests/SelectViewTests.swift
@@ -3,7 +3,7 @@
 //  Flow
 //
 //  Created by Emmanuel Garnier on 2017-07-20.
-//  Copyright © 2017 iZettle. All rights reserved.
+//  Copyright © 2017 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/TableChangeTests.swift
+++ b/FormTests/TableChangeTests.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Måns Bernhardt on 2016-10-11.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/TableKit+MasterSelectionBindingTests.swift
+++ b/FormTests/TableKit+MasterSelectionBindingTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/TableKitTests.swift
+++ b/FormTests/TableKitTests.swift
@@ -1,5 +1,5 @@
 // 
-// Copyright © 2019 iZettle. All rights reserved.
+// Copyright © 2019 PayPal Inc. All rights reserved.
 // 
 
 import XCTest

--- a/FormTests/TableTests.swift
+++ b/FormTests/TableTests.swift
@@ -3,7 +3,7 @@
 //  Form
 //
 //  Created by Emmanuel Garnier on 28/09/16.
-//  Copyright © 2016 iZettle. All rights reserved.
+//  Copyright © 2016 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/TextStyleTests.swift
+++ b/FormTests/TextStyleTests.swift
@@ -3,7 +3,7 @@
 //  FormTests
 //
 //  Created by Mayur Deshmukh on 12/02/19.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/UILabel+ScalingTests.swift
+++ b/FormTests/UILabel+ScalingTests.swift
@@ -3,7 +3,7 @@
 //  FormTests
 //
 //  Created by Nataliya Patsovska on 2019-12-13.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/UILabel+StylingTests.swift
+++ b/FormTests/UILabel+StylingTests.swift
@@ -3,7 +3,7 @@
 //  FormTests
 //
 //  Created by Nataliya Patsovska on 2019-03-19.
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/UIScrollView+PinningTests.swift
+++ b/FormTests/UIScrollView+PinningTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2019 iZettle. All rights reserved.
+//  Copyright © 2019 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/ValueEditorTests.swift
+++ b/FormTests/ValueEditorTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 iZettle. All rights reserved.
+//  Copyright © 2020 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/FormTests/ValueFieldTests.swift
+++ b/FormTests/ValueFieldTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 iZettle. All rights reserved.
+//  Copyright © 2020 PayPal Inc. All rights reserved.
 //
 
 import XCTest

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-present, iZettle AB
+Copyright (c) 2016-present, PayPal Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
### What has been done?
Replaced iZettle strings with PayPal equivalents

<!--- This can be a link to task or more detailed explaination --> 
### Why was it done?
The PayPal takeover and legal compliance