### PR TITLE
Add support for empty values in NumberEditor

### DIFF
--- a/FormTests/NumberEditorTests.swift
+++ b/FormTests/NumberEditorTests.swift
@@ -256,4 +256,17 @@ class DecimalEditorTests: XCTestCase {
         test(editor, "123456R3", "3", 3, 0)
         test(editor, "12345.6788R9", "9", 9, 0)
     }
+
+    func testEditing_whenEmptyValuesAreAllowed() {
+        let formatter = decimalFormatter
+        let editor = NumberEditor(formatter: formatter, allowsEmptyValues: true)
+
+        test(editor, "111<<<", "", .notANumber, 0)
+        test(editor, "111<<<<", "", .notANumber, 0)
+        test(editor, "111<<<0022.1", "22.1", 22.1, 0)
+        test(editor, "111<<<-22.1", "-22.1", -22.1, 0)
+        test(editor, "111r", "", .notANumber, 0)
+        test(editor, "-111r", "", .notANumber, 0)
+        test(editor, "111R234", "234", 234, 0)
+    }
 }


### PR DESCRIPTION
### What has been done?
This PR enables empty values in `ValueField`s backed by `NumberEditor`. The intended use case is being able to express `nil` values. Internally, empty values are mapped to `NSDecimalNumber.notANumber`. A proper implementation would require making `TextEditor.value` optional, but that would be a dramatic change of the API, so while the proposed solution is not ideal, it is much more conservative.

Empty values are enabled using the `allowsEmptyValues` parameter in the `NumberEditor` initializer, after which this behavior cannot be changed. This is done to avoid overcomplicating the internal logic in `NumberEditor`. Besides, it is probably unlikely that the desired behavior for a field will need to change during the lifetime of an editor.