### PR TITLE
Bump version to 3.0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ xcuserdata
 *.xccheckout
 .build
 .swiftpm
+default.profraw
 
 # ignore all Carthage output
 Carthage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5
+- Added: Support for empty values in NumberEditor ([#165](https://github.com/iZettle/Form/issues/165)).
+
 ## 3.0.4
 - Added: Highlight the text in ValueField when shouldResetOnInsertion is enabled ([#160](https://github.com/iZettle/Form/issues/160)).
 - Bugfix: `ValueField.shouldResetOnInsertion` has no effect for max length values ([#158](https://github.com/iZettle/Form/issues/158)).

--- a/Form.xcodeproj/project.pbxproj
+++ b/Form.xcodeproj/project.pbxproj
@@ -855,7 +855,7 @@
 				INFOPLIST_FILE = Form/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Form;
 				PRODUCT_NAME = Form;
 				SKIP_INSTALL = YES;
@@ -876,7 +876,7 @@
 				INFOPLIST_FILE = Form/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.0.4;
+				MARKETING_VERSION = 3.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Form;
 				PRODUCT_NAME = Form;
 				SKIP_INSTALL = YES;

--- a/FormFramework.podspec
+++ b/FormFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FormFramework"
-  s.version      = "3.0.4"
+  s.version      = "3.0.5"
   s.module_name  = "Form"
   s.summary      = "Powerful iOS layout and styling"
   s.description  = <<-DESC


### PR DESCRIPTION
## 3.0.5
- Added: Support for empty values in NumberEditor ([#165](https://github.com/iZettle/Form/issues/165)).
