### PR TITLE
PLT-2592 Expose the Contents of a `FormView` as Accessibility Elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.1
+
+- Improved the accessibility of `FormView` by making it an accessibility container comprising the visible rows from each of its visible sections.
+
 # 3.3.0
 
 - Added (backwards compatible) support for supplying an `accessibilityValue` to `ValueField` through `TextEditor`.

--- a/Form/FormView.swift
+++ b/Form/FormView.swift
@@ -39,6 +39,23 @@ public class FormView: UIStackView, DynamicStylable {
 }
 
 public extension FormView {
+
+    override var accessibilityElements: [Any]? {
+        get {
+            let visibleSections = sections.filter { !$0.isHidden }
+
+            var elements: [Any] = []
+            for section in visibleSections {
+                elements.append(contentsOf: section.accessibilityElements ?? [])
+            }
+
+            return elements
+        }
+
+        //swiftlint:disable:next unused_setter_value
+        set { /* Always computed */ }
+    }
+
     var sections: [SectionView] {
         return orderedViews.compactMap { $0 as? SectionView }
     }

--- a/Form/SectionView.swift
+++ b/Form/SectionView.swift
@@ -86,6 +86,29 @@ extension SectionView: SubviewOrderable {
 }
 
 public extension SectionView {
+
+    override var accessibilityElements: [Any]? {
+        get {
+            var elements: [Any] = []
+
+            if let header = headerView {
+                elements.append(header)
+            }
+
+            let visibleRows = orderedViews.filter { !$0.isHidden }
+            elements.append(contentsOf: visibleRows)
+
+            if let footer = footerView {
+                elements.append(footer)
+            }
+
+            return elements
+        }
+
+        //swiftlint:disable:next unused_setter_value
+        set { /* Always computed */ }
+    }
+
     var headerView: UIView? {
         return header.view
     }


### PR DESCRIPTION
## What has been done?

`FormView` now implements `UIAccessibilityContainer` by exposing its content through the `accessibilityElements` property. This is achieved through `SectionView` also adopting `UIAccessibilityContainer`, and returning its header (if it has one), its non-hidden rows, and its footer (if it has one) through `accessibilityElements`. `FormView` then implements `accessibilityElements` by taking the accessibility elements of all of its non-hidden sections, and returning them as a single, flattened array.

I'll tag 3.3.1 once this is merged.

## Why was it done?

Without this, only the visible rows of a `FormView` are reachable with VoiceOver.
