### PR TITLE
PLT-2592 Expose the Contents of a `FormView` as Accessibility Elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.2
+
+- Include all views, not just sections, in the accessibility elements of a FormView.
+
 # 3.3.1
 
 - Improved the accessibility of `FormView` by making it an accessibility container comprising the visible rows from each of its visible sections.

--- a/Form/FormView.swift
+++ b/Form/FormView.swift
@@ -42,14 +42,9 @@ public extension FormView {
 
     override var accessibilityElements: [Any]? {
         get {
-            let visibleSections = sections.filter { !$0.isHidden }
+            let visibleViews = orderedViews.filter { !$0.isHidden }
 
-            var elements: [Any] = []
-            for section in visibleSections {
-                elements.append(contentsOf: section.accessibilityElements ?? [])
-            }
-
-            return elements
+            return visibleViews
         }
 
         //swiftlint:disable:next unused_setter_value


### PR DESCRIPTION
## What has been done?

#176 exposed the contents of a `FormView` through its `accessibilityElements` property. A `FormView` can also contain other views besides its sections, and those views were not being included. This PR updates `FormView` so that all its 'ordered views' are included in its `accessibilityElements`.

I'll tag and release 3.3.2 once this is merged.

## Why was it done?

Without this, only the `SectionView`s of a `FormView` are reachable with VoiceOver.
