### PR TITLE
PLT-3491: Apply form styles to tableKit reordered cells

### DIFF
--- a/Form/TableKit.swift
+++ b/Form/TableKit.swift
@@ -587,6 +587,7 @@ private extension TableKit {
         for cell in self.view.visibleCells {
             guard let index = self.view.indexPath(for: cell), let tableIndex = TableIndex(index, in: table) else { continue }
             cell.updatePosition(position: position(tableIndex))
+            cell.applyFormStyle(style.style(from: cell.traitCollectionWithFallback))
         }
     }
 


### PR DESCRIPTION
A workaround is implemented in `UITableViewCell.applyFormStyle()` to change the position of reordering handles. They however retain their default position after reordering. As a fix, we call `applyFormStyle()` again after reordering.

 
https://user-images.githubusercontent.com/5547494/192750896-4552d8ae-09ee-4a89-ad33-cfd359f70b57.mov


https://user-images.githubusercontent.com/5547494/192750909-ccc46111-4fb0-43f5-bcd1-a4e12d8e8a38.mov

